### PR TITLE
fixed some errors after the addition of latent connections.

### DIFF
--- a/predictive_coding/config.py
+++ b/predictive_coding/config.py
@@ -14,3 +14,4 @@ class GPTConfig:
     n_blocks: int = 4
     batch_size: int = 8
     num_epochs: int = 5
+    use_lateral: bool = True

--- a/training.py
+++ b/training.py
@@ -1,5 +1,6 @@
 import torch
 import os
+import time
 import torch.nn.functional as F
 from tokenizers import Tokenizer
 from predictive_coding.config import GPTConfig
@@ -61,12 +62,13 @@ config = GPTConfig(
     n_embed=64,
     dropout=0.1,
     local_learning_rate=1e-7,
-    T=1,
+    T=2,
     is_holding_error = True,
     num_heads=2,
     n_blocks=2,
     num_epochs=5,
     update_bias=True,
+    use_lateral = True
 )
 
 model = PCTransformer(config)


### PR DESCRIPTION
## Summary
This PR fixes errors and improves functionality after the addition of latent (lateral) connections to our architecture [af66fee](https://github.com/iCog-Labs-Dev/PC-Transformers/pull/20/commits/af66fee5aea9cc208481bd446b117ebf83ec0bc4).

## Key Changes
- Fixed initialization and caching logic for input tensors and weights in `pc_layer.py`, ensuring correct handling when latent connections are enabled.
- Updated the step functions to handle the new return values, specifically for attention and linear layers.
- Adjusted the model configuration and training setup:
   - Added a use_lateral boolean flag to `config.py` for toggling lateral connections.
   - Ensured the use_lateral flag is passed and set consistently in training and model instantiation.
