### PR TITLE
Add configurable energy function and flexible model loading

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -10,7 +10,7 @@ import torch.nn.functional as F
 
 def load_model(model_path, config):
     model = PCTransformer(config)
-    model.load_state_dict(torch.load(model_path))
+    model.load_state_dict(torch.load(model_path),strict=False)
     return model
 
 def evaluate(model, dataloader, device):

--- a/model_architecture/attention.py
+++ b/model_architecture/attention.py
@@ -21,14 +21,16 @@ class Attention(nn.Module):
          self.pc_qkv=PCLayer(T= config.T,
             local_learning_rate=config.local_learning_rate,
             is_holding_error=config.is_holding_error,
-            update_bias = config.update_bias
+            update_bias = config.update_bias,
+            energy_fn_name=config.energy_fn_name,
         )
 
          self.pc_output = PCLayer(
             T=config.T,
             local_learning_rate=config.local_learning_rate,
             is_holding_error=config.is_holding_error,
-            update_bias = config.update_bias
+            update_bias = config.update_bias,
+            energy_fn_name=config.energy_fn_name,
         )
 
     def forward(self, fc1_x):

--- a/model_architecture/embedding.py
+++ b/model_architecture/embedding.py
@@ -15,6 +15,8 @@ class Embedding_Layer(nn.Module):
                                local_learning_rate=config.local_learning_rate,
                                is_holding_error= config.is_holding_error,
                                update_bias = config.update_bias,
+                               energy_fn_name=config.energy_fn_name,
+                               
                                )
       
     def forward(self, x_qkv, input_ids, position_ids)-> torch.Tensor:

--- a/model_architecture/mlp.py
+++ b/model_architecture/mlp.py
@@ -11,14 +11,17 @@ class MLP(nn.Module):
             T=config.T,
             local_learning_rate=config.local_learning_rate,
             is_holding_error=config.is_holding_error,
-            update_bias = config.update_bias
+            update_bias = config.update_bias,
+            energy_fn_name=config.energy_fn_name,
         )
 
         self.pc_layer1 = PCLayer(
             T=config.T,
             local_learning_rate=config.local_learning_rate,
             is_holding_error=config.is_holding_error,
-            update_bias = config.update_bias
+            update_bias = config.update_bias,
+            energy_fn_name=config.energy_fn_name,
+            
         )
         
     def forward(self, output_x):

--- a/model_architecture/output.py
+++ b/model_architecture/output.py
@@ -11,7 +11,8 @@ class OutputLayer(nn.Module):
             T=config.T,
             local_learning_rate=config.local_learning_rate,
             is_holding_error=config.is_holding_error,
-            update_bias = config.update_bias
+            update_bias = config.update_bias,
+            energy_fn_name=config.energy_fn_name,
         )
 
     def forward(self, target_ids) -> torch.Tensor:

--- a/predictive_coding/config.py
+++ b/predictive_coding/config.py
@@ -14,3 +14,4 @@ class GPTConfig:
     n_blocks: int = 4
     batch_size: int = 8
     num_epochs: int = 5
+    energy_fn_name: str = "scaled_mse" 

--- a/predictive_coding/pc_layer.py
+++ b/predictive_coding/pc_layer.py
@@ -10,6 +10,7 @@ class PCLayer(nn.Module):
         local_learning_rate: float = 1e-3,
         is_holding_error: bool = False,
         update_bias: bool = True,
+        energy_fn_name: str = "scaled_mse",
     ):
         super().__init__()
         self.T = T
@@ -19,7 +20,7 @@ class PCLayer(nn.Module):
         self.clamp_value = 1.0
         self._x_cache = {}
         self._W_cache = {}
-
+        self.energy_fn_name = energy_fn_name 
         self._energy = None
         self._errors = []
 

--- a/predictive_coding/pc_utils.py
+++ b/predictive_coding/pc_utils.py
@@ -5,7 +5,7 @@ import math
 def x_init(batch_size: int, seq_len: int, embedding_size: int) -> torch.Tensor:
     return torch.randn(batch_size, seq_len, embedding_size)
 
-def step_embed(t, target, layer, layer_type, input_ids, position_ids, local_lr, clamp_value, T, is_holding_error):
+def step_embed(t, target, layer, layer_type, input_ids, position_ids, local_lr, clamp_value, T,energy_fn_name, is_holding_error):
         word_layer = layer["word"]
         pos_layer = layer["pos"]
 
@@ -24,11 +24,11 @@ def step_embed(t, target, layer, layer_type, input_ids, position_ids, local_lr, 
                     pos_layer.weight.data[idx_p] += local_lr * update[b, s]
 
         if t == T - 1:
-            finalize_step(mu, target, error, t, layer_type, is_holding_error)
+            finalize_step(mu, target, error, t, layer_type,energy_fn_name, is_holding_error)
 
         return mu
     
-def step_linear(t, target, x, layer, layer_type, local_lr, clamp_value, T, is_holding_error,update_bias = True):
+def step_linear(t, target, x, layer, layer_type, local_lr, clamp_value, T, is_holding_error,energy_fn_name,update_bias = True):
         mu = layer(x)
         if layer_type == "fc1":
             mu = F.gelu(mu)
@@ -44,11 +44,11 @@ def step_linear(t, target, x, layer, layer_type, local_lr, clamp_value, T, is_ho
             layer.bias.data.add_(local_lr * error.mean(dim=(0, 1)))
 
         if t == T - 1:
-            finalize_step(mu, target, error, t, layer_type, is_holding_error)
+            finalize_step(mu, target, error, t, layer_type,energy_fn_name, is_holding_error)
 
         return x, mu
 
-def step_attn(t, target, x, proj_layers, layer_type, local_lr, clamp_value, T, is_holding_error, update_bias = True):
+def step_attn(t, target, x, proj_layers, layer_type, local_lr, clamp_value, T, is_holding_error,energy_fn_name, update_bias = True):
         q_proj = proj_layers["q_proj"]
         k_proj = proj_layers["k_proj"]
         v_proj = proj_layers["v_proj"]
@@ -70,14 +70,28 @@ def step_attn(t, target, x, proj_layers, layer_type, local_lr, clamp_value, T, i
                 proj.bias.data.add_(local_lr * error.mean(dim=(0, 1)))
 
         if t == T - 1:
-            finalize_step(mu, target, error, t, layer_type, is_holding_error)
+            finalize_step(mu, target, error, t, layer_type,energy_fn_name, is_holding_error)
 
         return x, mu
+    
+ENERGY_FUNCTIONS = {
+    "scaled_mse": lambda mu, x: ((mu - x) ** 2).mean(dim=-1) * 0.05,
+    "mse": lambda mu, x: ((mu - x) ** 2).mean(dim=-1),
+    "l1": lambda mu, x: (mu - x).abs().mean(dim=-1),
+    "cosine": lambda mu, x: 1 - torch.nn.functional.cosine_similarity(mu, x, dim=-1),
+    "kld": lambda mu, x: torch.nn.functional.kl_div(
+        mu.log_softmax(dim=-1),
+        x.softmax(dim=-1),
+        reduction='mean'
+    ).sum(dim=-1)
+}
 
-def energy_fn(mu: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
-    return ((mu - x) ** 2).mean(dim=-1) * 0.05
+def energy_fn(mu: torch.Tensor, x: torch.Tensor,energy_fn_name: str) -> torch.Tensor:
+    if energy_fn_name not in ENERGY_FUNCTIONS:
+        raise ValueError(f"Unknown energy function: {energy_fn_name}. Choose from {list(ENERGY_FUNCTIONS.keys())}")
+    return ENERGY_FUNCTIONS[energy_fn_name](mu, x)
 
-def finalize_step(mu, target, error, t, layer_type, is_holding_error = False):
-    energy = energy_fn(mu, target).mean().item() if is_holding_error else None
+def finalize_step(mu, target, error, t, layer_type,energy_fn_name, is_holding_error = False):
+    energy = energy_fn(mu, target,energy_fn_name).mean().item() if is_holding_error else None
     errors = [{"step": t, "type": layer_type, "error": error.mean().item()}]
     return energy, errors

--- a/training.py
+++ b/training.py
@@ -67,6 +67,7 @@ config = GPTConfig(
     n_blocks=2,
     num_epochs=5,
     update_bias=True,
+    energy_fn_name="kld" 
 )
 
 model = PCTransformer(config)


### PR DESCRIPTION
- Introduced a new energy function that calculates energy based on the energy_fn_name parameter provided.
- Updated finalize_step, step_embed, step_linear, and step_attn methods to accept the energy_fn_name parameter.
- Modified PC instances in each layer to initialize with the energy_fn_name parameter.
- Added energy_fn_name to the configuration settings.
- Set strict=False in eval.py to allow loading of saved state dictionaries with extra parameters not present in the model.