### PR TITLE
Add Mixed Precision (AMP) Support to Predictive Coding Training

### DIFF
--- a/training.py
+++ b/training.py
@@ -92,8 +92,9 @@ def train(model, dataloader, tokenizer, config, global_step, device):
                     _ = module._head_similarity_max
                     
         if layer_energies:
-            valid_energies = [e for e in layer_energies if not (torch.isnan(torch.tensor(e)) if isinstance(e, (int, float)) else True)]
-            batch_energy = sum(valid_energies) / len(valid_energies) if valid_energies else ce_loss.item()
+            energies_tensor = torch.tensor(layer_energies, device=device)
+            valid_energies = energies_tensor[~torch.isnan(energies_tensor)]
+            batch_energy = valid_energies.mean().item() if not valid_energies.numel() == 0 else ce_loss.item()
         else:
             batch_energy = ce_loss.item()
         total_energy += batch_energy


### PR DESCRIPTION
- Wrapped all major tensor operations in step_embed, step_linear, and step_attn (in utils/pc_utils.py) with torch.amp.autocast('cuda') when running on CUDA.
- Ensured that all predictive coding local update steps benefit from mixed precision, without altering the custom local learning logic.
- Updated the autocast API to the latest PyTorch standard to avoid deprecation warnings.
- No Changes to Training Logic

without the amp
real    77m1.387s
user    63m26.574s
sys     13m11.352s

With the amp added
real    75m15.791s
user    60m1.588s
sys     14m52.895s

- Overall training time reduced by ~2%.
- No observed loss in model stability or accuracy.