### PR TITLE
layer specific energy 

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -13,19 +13,23 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 import torch.distributed as dist
 
 """Usage: torchrun --nproc-per-node=2 eval.py"""
-local_rank = int(os.getenv("LOCAL_RANK", 0))
-device = torch.device(f"cuda:{local_rank}" if torch.cuda.is_available() else "cpu")
 
 local_rank = int(os.getenv("LOCAL_RANK", 0))
 device = torch.device(f"cuda:{local_rank}" if torch.cuda.is_available() else "cpu")
 
 def evaluate(model, dataloader, tokenizer, max_batches=None, device = None):
     model.eval()
-    total_energy = 0.0
+    total_combined_energy = 0.0
     batch_count = 0
     total_ce_loss = 0.0
     pad_token_id = tokenizer.pad_token_id
     vocab_size = len(tokenizer)
+    
+    base_model = model.module if hasattr(model, 'module') else model
+    output_pc_layer = base_model.output.pc_layer
+
+    alpha = getattr(base_model.config, 'combined_internal_weight', 0.3)
+    beta = getattr(base_model.config, 'combined_output_weight', 0.7)
     
     if local_rank == 0:
         if max_batches is None:
@@ -56,37 +60,43 @@ def evaluate(model, dataloader, tokenizer, max_batches=None, device = None):
         )
         total_ce_loss += ce_loss.item()
 
-        layer_energies = []
+        internal_energies = []
+        output_energy = None
+
         for module in model.modules():
             if isinstance(module, PCLayer) and hasattr(module, "get_energy"):
                 energy = module.get_energy()
-                if energy is not None and not torch.isnan(torch.tensor(energy)):
-                    layer_energies.append(energy)
+                if energy is None or (isinstance(energy, float) and math.isnan(energy)):
+                    continue
 
-        if layer_energies:
-            valid_energies = [e for e in layer_energies if not torch.isnan(torch.tensor(e))]
-            batch_energy = sum(valid_energies) / len(valid_energies) if valid_energies else ce_loss.item()
-        else:
-            batch_energy = ce_loss.item()
+                if module is output_pc_layer:
+                    output_energy = energy
+                else:
+                    internal_energies.append(energy)
 
-        total_energy += batch_energy
+        avg_internal_energy = sum(internal_energies) / len(internal_energies) if internal_energies else ce_loss.item()
+        avg_output_energy = output_energy if output_energy is not None else ce_loss.item()
+
+        combined_energy = alpha * avg_internal_energy + beta * avg_output_energy
+        total_combined_energy += combined_energy
         batch_count += 1
 
         if dist.get_rank() == 0 and (batch_idx + 1) % 10 == 0:
-            print(f"  Batch {batch_idx + 1}/{len(dataloader)} | CE Loss: {ce_loss.item():.4f}| Batch Energy: {batch_energy:.4f}", flush=True)
+            print(f"  Batch {batch_idx + 1}/{len(dataloader)} | CE Loss: {ce_loss.item():.4f}|  Combined Energy: { combined_energy:.4f}", flush=True)
 
         reset_pc_modules(model)
         cleanup_memory()
 
-    avg_energy = total_energy / batch_count if batch_count > 0 else 0.0
+    avg_combined_energy = total_combined_energy / batch_count if batch_count > 0 else 0.0
     avg_ce_loss = total_ce_loss / batch_count if batch_count > 0 else 0.0
     avg_perplexity = math.exp(avg_ce_loss) if avg_ce_loss < 100 else float("inf")
 
+    
     if local_rank == 0:
         print(f"Total Batches Processed: {batch_idx + 1}")
-        print(f"Avg CE Loss: {avg_ce_loss:.4f} | Avg Energy: {avg_energy:.4f} | Avg Perplexity: {avg_perplexity:.4f}")
+        print(f"Avg CE Loss: {avg_ce_loss:.4f} | avg_combined_energy: {avg_combined_energy:.4f} | Avg Perplexity: {avg_perplexity:.4f}")
 
-    return avg_energy, avg_ce_loss, avg_perplexity
+    return avg_combined_energy, avg_perplexity
 
 def main():
     dist.init_process_group(backend="nccl")
@@ -106,8 +116,11 @@ def main():
         n_blocks=6,
         num_epochs=1,
         update_bias=False,
-        energy_fn_name="scaled_mse", 
-        eos_token_id = tokenizer.eos_token_id
+        internal_energy_fn_name="mse", 
+        output_energy_fn_name="kld",
+        eos_token_id = tokenizer.eos_token_id,
+        combined_internal_weight=0.3,
+        combined_output_weight=0.7
     )
 
     model_path = "checkpoints/final_model.pt"

--- a/eval.py
+++ b/eval.py
@@ -128,7 +128,8 @@ def main():
         output_energy_fn_name="kld",
         eos_token_id = tokenizer.eos_token_id,
         combined_internal_weight=0.3,
-        combined_output_weight=0.7
+        combined_output_weight=0.7,
+        use_flash_attention=True
     )
 
     model_path = "checkpoints/final_model.pt"

--- a/model_architecture/attention.py
+++ b/model_architecture/attention.py
@@ -32,7 +32,7 @@ class Attention(nn.Module):
             local_learning_rate=config.local_learning_rate,
             is_holding_error=config.is_holding_error,
             update_bias = config.update_bias,
-            energy_fn_name=config.energy_fn_name,
+            energy_fn_name=config.internal_energy_fn_name,
             num_heads=config.num_heads,
             n_embed=config.n_embed,
             la = config.la            
@@ -43,5 +43,5 @@ class Attention(nn.Module):
             local_learning_rate=config.local_learning_rate,
             is_holding_error=config.is_holding_error,
             update_bias = config.update_bias,
-            energy_fn_name=config.energy_fn_name,
+            energy_fn_name=config.internal_energy_fn_name,
         )

--- a/model_architecture/embedding.py
+++ b/model_architecture/embedding.py
@@ -24,6 +24,6 @@ class Embedding_Layer(nn.Module):
                                local_learning_rate=config.local_learning_rate,
                                is_holding_error= config.is_holding_error,
                                update_bias = config.update_bias,
-                               energy_fn_name=config.energy_fn_name,
+                               energy_fn_name=config.internal_energy_fn_name,
                                
                                )

--- a/model_architecture/mlp.py
+++ b/model_architecture/mlp.py
@@ -25,7 +25,7 @@ class MLP(nn.Module):
             local_learning_rate=config.local_learning_rate,
             is_holding_error=config.is_holding_error,
             update_bias=config.update_bias,
-            energy_fn_name=config.energy_fn_name,
+            energy_fn_name=config.internal_energy_fn_name,
         )
 
         self.pc_layer1 = PCLayer(
@@ -33,5 +33,5 @@ class MLP(nn.Module):
             local_learning_rate=config.local_learning_rate,
             is_holding_error=config.is_holding_error,
             update_bias=config.update_bias,
-            energy_fn_name=config.energy_fn_name,
+            energy_fn_name=config.internal_energy_fn_name,
         )

--- a/model_architecture/output.py
+++ b/model_architecture/output.py
@@ -21,5 +21,5 @@ class OutputLayer(nn.Module):
             local_learning_rate=config.local_learning_rate,
             is_holding_error=config.is_holding_error,
             update_bias = config.update_bias,
-            energy_fn_name=config.energy_fn_name,
+            energy_fn_name=config.output_energy_fn_name,
         )

--- a/predictive_coding/config.py
+++ b/predictive_coding/config.py
@@ -47,6 +47,7 @@ class GPTConfig:
     batch_size: int = 8
     num_epochs: int = 5
     use_lateral: bool = True
-    energy_fn_name: str = "mse"
+    internal_energy_fn_name:str="scaled_mse",
+    output_energy_fn_name: str="kld",
     eos_token_id: int = None
     use_flash_attention: bool = False

--- a/predictive_coding/config.py
+++ b/predictive_coding/config.py
@@ -51,3 +51,5 @@ class GPTConfig:
     output_energy_fn_name: str="kld",
     eos_token_id: int = None
     use_flash_attention: bool = False
+    combined_internal_weight: float = 0.3
+    combined_output_weight: float = 0.7

--- a/training.py
+++ b/training.py
@@ -101,7 +101,7 @@ def train(model, dataloader, tokenizer, config, global_step, device):
 
         if dist.get_rank() == 0 and (batch_idx + 1) % 10 == 0:
             print(f"  Batch {batch_idx + 1}/{len(dataloader)} | "
-                  f"Combined: {combined_energy:.4f} | "
+                  f"Combined_energy: {combined_energy:.4f} | "
                   f"Perplexity: {perplexity:.4f}", flush=True)
 
         reset_pc_modules(model)
@@ -186,7 +186,7 @@ def main():
         if rank == 0:
             print(f"Epoch {epoch + 1}/{config.num_epochs} | "
                   f"Train Combined_energy: {train_combined_energy:.4f} | Train PPL: {train_perplexity:.4f} | "
-                  f"Val Combined: {val_combined_energy:.4f} | Val PPL: {val_perplexity:.4f}")
+                  f"Val Combined_energy: {val_combined_energy:.4f} | Val PPL: {val_perplexity:.4f}")
 
             if (epoch + 1) % 5 == 0 or epoch == config.num_epochs - 1:
                 os.makedirs("checkpoints", exist_ok=True)

--- a/training.py
+++ b/training.py
@@ -127,7 +127,7 @@ def main():
         block_size=128,
         n_embed=256,
         n_blocks=4,
-        T=5,
+        T=2,
         local_learning_rate=0.0,
         peak_learning_rate=2e-5,
         warmup_steps=200,
@@ -135,7 +135,7 @@ def main():
         is_holding_error=True,
         update_bias=True,
         num_heads=8,
-        num_epochs=10,
+        num_epochs=1,
         use_lateral=True,
         internal_energy_fn_name="mse",
         output_energy_fn_name="kld",
@@ -163,7 +163,8 @@ def main():
         print(f"{total_params / 1e6:.2f} M parameters", flush=True)
 
     for epoch in range(config.num_epochs):
-        if hasattr(train_loader.sample, "sampler") and isinstance(train_loader.sampler, torch.utils.data.DistributedSampler):
+        if isinstance(train_loader.sampler, torch.utils.data.distributed.DistributedSampler):
+
             train_loader.sampler.set_epoch(epoch)
         
 

--- a/training.py
+++ b/training.py
@@ -127,7 +127,7 @@ def main():
         block_size=128,
         n_embed=256,
         n_blocks=4,
-        T=2,
+        T=5,
         local_learning_rate=0.0,
         peak_learning_rate=2e-5,
         warmup_steps=200,
@@ -135,7 +135,7 @@ def main():
         is_holding_error=True,
         update_bias=True,
         num_heads=8,
-        num_epochs=1,
+        num_epochs=10,
         use_lateral=True,
         internal_energy_fn_name="mse",
         output_energy_fn_name="kld",
@@ -164,7 +164,6 @@ def main():
 
     for epoch in range(config.num_epochs):
         if isinstance(train_loader.sampler, torch.utils.data.distributed.DistributedSampler):
-
             train_loader.sampler.set_epoch(epoch)
         
 
@@ -186,7 +185,7 @@ def main():
 
         if rank == 0:
             print(f"Epoch {epoch + 1}/{config.num_epochs} | "
-                  f"Train Combined: {train_combined_energy:.4f} | Train PPL: {train_perplexity:.4f} | "
+                  f"Train Combined_energy: {train_combined_energy:.4f} | Train PPL: {train_perplexity:.4f} | "
                   f"Val Combined: {val_combined_energy:.4f} | Val PPL: {val_perplexity:.4f}")
 
             if (epoch + 1) % 5 == 0 or epoch == config.num_epochs - 1:

--- a/utils/pc_utils.py
+++ b/utils/pc_utils.py
@@ -246,7 +246,7 @@ ENERGY_FUNCTIONS = {
     "cosine": lambda mu, x: 1 - F.cosine_similarity(mu, x, dim=-1),
     "kld": lambda mu, x: torch.clamp(F.kl_div(
         mu.log_softmax(dim=-1),
-        x.softmax(dim=-1),
+        x,
         reduction='batchmean'
     ), min=0.0, max=100.0)
 }


### PR DESCRIPTION
This PR enhances the Predictive Coding Transformer (PCT) model by introducing layer-specific energy functions and a combined energy metric for training visibility and model interpretability.

Instead of using a single global energy function for all layers, we now:

Use **MSE** for internal layers (embedding, attention, MLP)
Use **KLD** for the output layer
Compute a weighted combined energy to track overall model performance:
combined_energy=α * internal_energy + β * output_energy
where:

α=0.3 , β=0.7 (configurable via combined_internal_weight and combined_output_weight)
internal_energy = average of all non-output PCLayer energies
output_energy = KLD between predicted logits and one-hot targets