### PR TITLE
Add CUDA Stream Support for PCTransformer Parallelization

### DIFF
--- a/Data_preprocessing/config.py
+++ b/Data_preprocessing/config.py
@@ -4,7 +4,7 @@ class Config:
     PAD_ID=None
     EOS_ID=None
     MAX_LENGTH = 128
-    DATASET_NAME = "ptb"  # "ptb" for penntreebank "opwb" for OpenWebText
+    DATASET_NAME = "opwb"  # "ptb" for penntreebank "opwb" for OpenWebText
     BASE_DIR = os.path.dirname(os.path.abspath(__file__)) 
     DATA_DIR = os.path.join(BASE_DIR, "Data") 
     TOKENIZER_DIR = os.path.join(BASE_DIR, "tokenizer", "outputs")  

--- a/Data_preprocessing/config.py
+++ b/Data_preprocessing/config.py
@@ -4,7 +4,7 @@ class Config:
     PAD_ID=None
     EOS_ID=None
     MAX_LENGTH = 128
-    DATASET_NAME = "opwb"  # "ptb" for penntreebank "opwb" for OpenWebText
+    DATASET_NAME = "ptb"  # "ptb" for penntreebank "opwb" for OpenWebText
     BASE_DIR = os.path.dirname(os.path.abspath(__file__)) 
     DATA_DIR = os.path.join(BASE_DIR, "Data") 
     TOKENIZER_DIR = os.path.join(BASE_DIR, "tokenizer", "outputs")  

--- a/utils/device_utils.py
+++ b/utils/device_utils.py
@@ -18,3 +18,32 @@ def create_streams_or_futures(device: torch.device, num_streams: int) -> tuple[b
     if use_cuda:
         return True, [torch.cuda.Stream(device=device) for _ in range(num_streams)]
     return False, []
+def execute_parallel(
+    use_cuda: bool,
+    streams_or_futures: List[Any],
+    forward_fn: Callable,
+    *args,
+    **kwargs
+) -> Optional[Any]:
+    """
+    Executes a forward function in parallel using either CUDA streams or torch.jit.fork.
+
+    Args:
+        use_cuda (bool): Whether to use CUDA streams (True) or torch.jit.fork (False).
+        streams_or_futures (List[Any]): List of streams (for CUDA) or futures (for CPU).
+        forward_fn (Callable): The forward function to execute.
+        *args: Positional arguments for the forward function.
+        **kwargs: Keyword arguments for the forward function.
+
+    Returns:
+        Optional[Any]: The future object if using torch.jit.fork, None if using CUDA streams.
+    """
+    if use_cuda:
+        stream_idx = len(streams_or_futures) - len([s for s in streams_or_futures if not s]) - 1
+        with torch.cuda.stream(streams_or_futures[stream_idx]):
+            forward_fn(*args, **kwargs)
+        return None
+    else:
+        future = torch.jit.fork(forward_fn, *args, **kwargs)
+        streams_or_futures.append(future)
+        return future

--- a/utils/device_utils.py
+++ b/utils/device_utils.py
@@ -1,0 +1,20 @@
+import torch
+from typing import List, Callable, Any, Optional
+
+def create_streams_or_futures(device: torch.device, num_streams: int) -> tuple[bool, List[Any]]:
+    """
+    Creates CUDA streams or an empty futures list based on the device.
+
+    Args:
+        device (torch.device): The device to check (CPU or CUDA).
+        num_streams (int): Number of streams/futures needed.
+
+    Returns:
+        tuple[bool, List[Any]]: A tuple containing:
+            - use_cuda (bool): Whether to use CUDA streams.
+            - streams_or_futures (List[Any]): List of CUDA streams or empty futures list.
+    """
+    use_cuda = torch.cuda.is_available() and device.type == 'cuda'
+    if use_cuda:
+        return True, [torch.cuda.Stream(device=device) for _ in range(num_streams)]
+    return False, []


### PR DESCRIPTION
This pull request enhances the `PCTransformer` model's forward method by introducing support for CUDA stream-based parallelization on GPU devices, while retaining the existing `torch.jit.fork` implementation for CPU devices. The implementation switches between `torch.jit.fork` (for CPU) and `torch.cuda.stream` (for CUDA/GPU) based on the device of the input tensors, improving performance and flexibility across different hardware environments.

**1. Modularization of Device-Specific Logic**: Extracted device-specific parallelism logic (previously mixing `torch.jit.fork` for CPU and `torch.cuda.stream` for CUDA) into a new `utils/device_utils.py` file with reusable utility.
- utility function to create CUDA streams  or an empty futures list based on the device. [d4fcc74
](https://github.com/iCog-Labs-Dev/PC-Transformers/commit/d4fcc748dc1e127d98aa609739bcd6b2adef6f4d)
- utility function to execute the forward function in parallel using either CUDA streams or `torch.jit.fork`. [5665cbe
](https://github.com/iCog-Labs-Dev/PC-Transformers/commit/5665cbe1d6f8691e231ec54e26e029133a13ad70)
- utility function to synchronize CUDA streams or wait for `torch.jit.fork` futures to complete. [710ce11
](https://github.com/iCog-Labs-Dev/PC-Transformers/commit/710ce1100806da936671f82f8d85ad05e373c971)

**2. Dynamic Parallelism Support**: Retained the dynamic switching between `torch.jit.fork` for CPU and `torch.cuda.stream` for CUDA devices, introduced in the previous implementation, to optimize performance across hardware. [29cb6f4
](https://github.com/iCog-Labs-Dev/PC-Transformers/commit/29cb6f42248e6528f1c86a3afda3c7c1ae1659e1)

**3. Simplified forward Method**: Streamlined the forward method by leveraging utility functions, making it more focused on model logic and easier to maintain.