### PR TITLE
Add Training Logging with File and terminal output functionality

### DIFF
--- a/training.py
+++ b/training.py
@@ -15,6 +15,7 @@ from eval import evaluate
 from visualization import plot_metrics
 import torch.distributed as dist
 from torch.nn.parallel import DistributedDataParallel as DDP
+import json
 import logging
 
 """
@@ -146,6 +147,17 @@ def main():
         eos_token_id = tokenizer.eos_token_id,
         use_flash_attention=True
     )
+
+    if rank == 0:
+        logger.info(f"\n{'#' * 120}\n") # add a line of '#' characters to separate each training
+        logger.info("Saving the hyperparameters configuration:")
+        try:
+            cfg = config.__dict__
+        except Exception:
+            cfg = {k: getattr(config, k) for k in dir(config) if not k.startswith("_") and not callable(getattr(config, k))}
+        config_json = json.dumps(cfg, indent=6, default=str)
+        logger.info(config_json)
+    
     model = PCTransformer(config).to(device)
     model = DDP(model, device_ids=[local_rank], 
                 output_device=local_rank, 
@@ -162,7 +174,6 @@ def main():
     
     # rank = dist.get_rank() if dist.is_initialized() else 0
     if rank == 0:
-        logger.info(f"\n{'#' * 120}\n") # add a line of '#' characters to separate each training
         logger.info("========== Training started ==========") 
         logger.info(f"{sum(p.numel() for p in model.parameters())/1e6:.2f} M parameters")
         
@@ -179,7 +190,7 @@ def main():
         val_energies.append(val_energy)
 
         if rank == 0:
-            # add horizontal bar
+            # add horizontal line to separate each epoch
             logger.info("-" * 100)
             logger.info(f"Epoch {epoch+1}/{config.num_epochs}")
             logger.info(f"{'Metrics':<20} {'Training':<15} {'Validation':<15}")


### PR DESCRIPTION
### Intro
This PR introduces training logging to save training ouput to a dedicated `logs/training.log` file and display it in the console/terminal at the same time. This is useful for those without GPU access, who cannot train the model by themselves but can still analyze the logged output to understand the training process. 

#### Objective
Saving the training output to the `logs/training.log` file will help us understand what is happening when a model is being trained, especially for those who don’t have GPU access and are not be able to train the model on their own. and the exact hyperparameters and flags are preserved in the log so runs can be re-created later with that configuration.

#### Changes
- Added `logging` module configuration to save logs to `logs/training.log` and print to the console.

1. **Logging Configuration**:
   ```python
   log_dir = 'logs'
   os.makedirs(log_dir, exist_ok=True)
   logging.basicConfig(
       level=logging.INFO,
       format='%(asctime)s - %(levelname)s - %(message)s',
       handlers=[
           logging.FileHandler(os.path.join(log_dir, 'training.log')),
           logging.StreamHandler()
       ]
   )
   logger = logging.getLogger(__name__)
   ```
   - This creates a `logs` directory (if it doesn’t exist), configures logging to write to `training.log`, and outputs to the console. The `format` includes timestamps

2. **log output in `train` function**:
   ```python
   if dist.get_rank() == 0 and (batch_idx + 1) % 10 == 0:
       logger.info(f"  Batch {batch_idx + 1}/{len(dataloader)} | Batch Energy: {batch_energy:.4f} | Perplexity: {perplexity:.4f}")
   ```
   - This logs the batch number, energy, and perplexity every 10 batches, visible in both the file and console.

3. **log output in `main` function**:
   ```python
   if rank == 0:
       logger.info(f"\n{'#' * 120}\n")
       logger.info("========== Training started ==========")
       logger.info(f"{sum(p.numel() for p in model.parameters())/1e6:.2f} M parameters")
   ```
   -  This adds a separator line and logs the start of training with the total parameter count (e.g., "2.34 M parameters").

#### Example Output
Here is a sample output in a `logs/training.log` file and terminal when running the training python script:
```
2025-08-05 16:01:23,456 - INFO - Using device: cuda:0 (local rank 0)
2025-08-05 16:01:23,789 - INFO - 
########################################################################################################################
# HyperParamenters configuration will be recorded here.

2025-08-05 16:01:23,790 - INFO - ========== Training started ==========
2025-08-05 16:01:23,791 - INFO - 2.34 M parameters
2025-08-05 16:01:23,792 - INFO - ---------------------------------------------------------------------------------
2025-08-05 16:01:24,123 - INFO - Epoch 1/20
2025-08-05 16:01:24,124 - INFO - Metrics                Training              Validation       
2025-08-05 16:01:24,125 - INFO - Energy                  0.5678                0.5890           
2025-08-05 16:01:24,126 - INFO - Perplexity              45.6789               46.1234          
2025-08-05 16:01:24,128 - INFO - Saved checkpoint to checkpoints/model_epoch_5.pt
2025-08-05 16:01:24,129 - INFO - ---------------------------------------------------------------------------------
2025-08-05 16:01:24,130 - INFO - Epoch 2/20
    ...  # continue like epoch-1 for the rest of epochs as well
        
2025-08-05 16:01:24,456 - INFO - Training completed in 60.34 seconds
2025-08-05 16:01:24,457 - INFO - Final model saved to: checkpoints/final_model.pt
2025-08-05 16:01:24,458 - INFO - ========== Training completed ==========
```
- The log file captures the training metrics results and the exact hyperparameters are preserved in the log so runs can be re-done later with the desired config.