### PR TITLE
Enable Automatic Mixed Precision and update training settings

### DIFF
--- a/utils/pc_utils.py
+++ b/utils/pc_utils.py
@@ -3,6 +3,8 @@ import torch.nn as nn
 import torch.nn.functional as F
 import math
 import gc
+from torch.amp import autocast
+from contextlib import nullcontext
 from predictive_coding.config import GPTConfig
 from utils.attention_utils import apply_flash_attention, apply_standard_attention
 
@@ -62,6 +64,9 @@ def step_embed(t, T, target, layer, layer_type, input_ids, position_ids, local_l
     """
     word_layer = layer["word"]
     pos_layer = layer["pos"]
+    
+    use_amp = target.is_cuda
+    autocast_ctx = autocast('cuda') if use_amp else nullcontext()
 
     # Clip input_ids and position_ids to valid ranges
     vocab_size = word_layer.weight.size(0)
@@ -71,22 +76,25 @@ def step_embed(t, T, target, layer, layer_type, input_ids, position_ids, local_l
     max_pos = pos_layer.weight.size(0)
     if position_ids.max() >= max_pos:
         position_ids = torch.clamp(position_ids, max=max_pos-1)
+        
+    
+    with autocast_ctx:
+        if requires_update or mu_word_cache is None or mu_pos_cache is None:
+            mu_word = word_layer(input_ids)
+            mu_pos = pos_layer(position_ids)
+        else:
+            mu_word = mu_word_cache
+            mu_pos = mu_pos_cache
+        mu = mu_word + mu_pos
 
-    if requires_update or mu_word_cache is None or mu_pos_cache is None:
-        mu_word = word_layer(input_ids)
-        mu_pos = pos_layer(position_ids)
-    else:
-        mu_word = mu_word_cache
-        mu_pos = mu_pos_cache
-    mu = mu_word + mu_pos
+        if not requires_update:
+            if t == T - 1:
+                finalize_step(mu, target, mu - mu, t, layer_type, energy_fn_name, is_holding_error)
+            return mu, mu_word, mu_pos
 
-    if not requires_update:
-        if t == T - 1:
-            finalize_step(mu, target, mu - mu, t, layer_type, energy_fn_name, is_holding_error)
-        return mu, mu_word, mu_pos
-
-    error = target - mu
-    update = torch.clamp(error, -clamp_value, clamp_value)
+        error = target - mu
+        update = torch.clamp(error, -clamp_value, clamp_value)
+        
     if requires_update: 
         with torch.no_grad():
             flat_input_ids = input_ids.reshape(-1)
@@ -127,30 +135,34 @@ def step_linear(t, T, target, x, layer, W_latents, layer_type, local_lr, clamp_v
         tuple: (updated activity tensor, predicted output tensor)
     """
     device = x.device
-    mu = layer(x)
-    if layer_type == "fc1":
-        mu = F.gelu(mu)
-
-    error = target - mu
-    if layer.weight.shape[0] != layer.weight.shape[1]:
-        error_proj = torch.einsum("bsh, vh -> bsv", error, layer.weight.T)  
-    else:
-        error_proj = error  
-
-    if use_lateral and layer_type in W_latents:
-        W_latent = W_latents[layer_type].to(device) 
-        x_latent = torch.einsum("bsh,hv->bsv", x, W_latent)
-        delta_x = error_proj + x_latent
-        x = x + local_lr * delta_x
-
-        if requires_update:
-            anti_hebbian_latent = -torch.einsum("bsh,bsv->hv", x.detach(), x.detach())
-            W_latents[layer_type] = W_latents[layer_type] + local_lr * anti_hebbian_latent
+    use_amp = target.is_cuda
+    autocast_ctx = autocast('cuda') if use_amp else nullcontext()
     
-    else:
-        x= x + local_lr * error 
-    
-    x = torch.clamp(x, -clamp_value, clamp_value)
+    with autocast_ctx:
+        mu = layer(x)
+        if layer_type == "fc1":
+            mu = F.gelu(mu)
+
+        error = target - mu
+        if layer.weight.shape[0] != layer.weight.shape[1]:
+            error_proj = torch.einsum("bsh, vh -> bsv", error, layer.weight.T)  
+        else:
+            error_proj = error  
+
+        if use_lateral and layer_type in W_latents:
+            W_latent = W_latents[layer_type].to(device) 
+            x_latent = torch.einsum("bsh,hv->bsv", x, W_latent)
+            delta_x = error_proj + x_latent
+            x = x + local_lr * delta_x
+
+            if requires_update:
+                anti_hebbian_latent = -torch.einsum("bsh,bsv->hv", x.detach(), x.detach())
+                W_latents[layer_type] = W_latents[layer_type] + local_lr * anti_hebbian_latent
+        
+        else:
+            x= x + local_lr * error 
+        
+        x = torch.clamp(x, -clamp_value, clamp_value)
     
     # Hebbian Update W_layer
     if requires_update:
@@ -171,37 +183,42 @@ def step_attn(t, T, target, x, W_latents, proj_layers, layer_type, local_lr, cla
         q_proj = proj_layers.get("q_proj", None)
         k_proj = proj_layers.get("k_proj", None)
         v_proj = proj_layers.get("v_proj", None)
+        assert all(p is not None for p in (q_proj, k_proj, v_proj)), "Missing Q/K/V projections in dict"    
         
-        assert all(p is not None for p in (q_proj, k_proj, v_proj)), "Missing Q/K/V projections in dict"        
-        Q= q_proj(x)
-        K= k_proj(x)
-        V= v_proj(x)
+        use_amp = target.is_cuda
+        autocast_ctx = autocast('cuda') if use_amp else nullcontext()
+        
         batch_size, seq_len, embed_dim = target.shape
         head_dim = n_embed // num_heads
         la = la * math.sqrt(1.0 / head_dim)
 
-        Q = Q.view(batch_size, num_heads, seq_len, head_dim).transpose(1, 2)
-        K = K.view(batch_size, num_heads, seq_len, head_dim).transpose(1, 2)
-        V = V.view(batch_size, num_heads, seq_len, head_dim).transpose(1, 2)
+        with autocast_ctx:      
+            Q= q_proj(x)
+            K= k_proj(x)
+            V= v_proj(x)
+            
+            Q = Q.view(batch_size, num_heads, seq_len, head_dim).transpose(1, 2)
+            K = K.view(batch_size, num_heads, seq_len, head_dim).transpose(1, 2)
+            V = V.view(batch_size, num_heads, seq_len, head_dim).transpose(1, 2)
 
-        if flash:
-            mu_heads = apply_flash_attention(Q, K, V)
-        else:
-            mu_heads = apply_standard_attention(Q, K, V)
+            if flash:
+                mu_heads = apply_flash_attention(Q, K, V)
+            else:
+                mu_heads = apply_standard_attention(Q, K, V)
 
-        dvl_grad = compute_DVL(mu_heads, requires_update)
-        if dvl_grad is not None:
-            dvl_grad = dvl_grad.to(device)
-        dvl_norm = dvl_grad.norm().item() if dvl_grad is not None else 0.0
-        similarity = get_head_similarity(mu_heads)
-        mu = mu_heads.transpose(1, 2).contiguous().view(batch_size, seq_len, embed_dim)
-     
-        error = target - mu  # B, T, D
-        if dvl_grad is not None:
-            B, T, H, D = dvl_grad.shape
-            dvl_projected = dvl_grad.permute(0, 2, 1, 3).contiguous().view(B, T, -1)
-            dvl_projected=dvl_projected.clamp(-1e-3, 1e-3)
-            error = error + la * dvl_projected
+            dvl_grad = compute_DVL(mu_heads, requires_update)
+            if dvl_grad is not None:
+                dvl_grad = dvl_grad.to(device)
+            dvl_norm = dvl_grad.norm().item() if dvl_grad is not None else 0.0
+            similarity = get_head_similarity(mu_heads)
+            mu = mu_heads.transpose(1, 2).contiguous().view(batch_size, seq_len, embed_dim)
+        
+            error = target - mu  # B, T, D
+            if dvl_grad is not None:
+                B, T, H, D = dvl_grad.shape
+                dvl_projected = dvl_grad.permute(0, 2, 1, 3).contiguous().view(B, T, -1)
+                dvl_projected=dvl_projected.clamp(-1e-3, 1e-3)
+                error = error + la * dvl_projected
         
         if layer_instance is not None:
             setattr(layer_instance, '_head_similarity', similarity)


### PR DESCRIPTION
This PR introduces **Automatic Mixed Precision (AMP)** for training the PC Transformer, reducing GPU memory usage and slightly speeding up training.

### Commit Reference
Related commit: [cbed1fe](https://github.com/iCog-Labs-Dev/PC-Transformers/commit/cbed1fe1daf8f7677704d48556a84d6fff4bba4c)


### Configurations used to compare updates with and without AMP:
- **Hyperparameters**:
  - `block_size = 256`
  - `warmup_steps = 2`
  - `n_embed = 64`
  - `T = 2`
  - `num_heads = 2`
  - `n_blocks = 2`
  - `num_epochs = 2`
  - `batch_size = 8`
  
- **Dataloader**: set to load only a 0.001 sample ratio for faster testing



### Results Comparison:

| Metric | With AMP | Without AMP | Difference |
|--------|----------|------------|------------|
| Peak memory (MB) | 2427 | 2960 | -18% less memory |
| Training time (s) | 2069.6 | 2101.4 | ~1.5% faster |

