### PR TITLE
Add Causal Masking to Standard Attention

### DIFF
--- a/utils/pc_utils.py
+++ b/utils/pc_utils.py
@@ -210,11 +210,16 @@ def step_attn(t, T, target, x, W_latents, proj_layers, layer_type, local_lr, cla
             Q = Q.view(batch_size, num_heads, seq_len, head_dim)
             K = K.view(batch_size, num_heads, seq_len, head_dim)
             V = V.view(batch_size, num_heads, seq_len, head_dim)
+            
+            #create causal mask (1=keep, 0=mask)
+            causal_mask = torch.tril(torch.ones(seq_len, seq_len, device=device)).unsqueeze(0).unsqueeze(0)
 
+            # !! Causal Mask
             if flash:
+                # TODO: add support for causal masking in flash attention
                 mu_heads = apply_flash_attention(Q, K, V)
             else:
-                mu_heads = apply_standard_attention(Q, K, V)
+                mu_heads = apply_standard_attention(Q, K, V, mask=causal_mask)
 
             dvl_grad = compute_DVL(mu_heads, requires_update)
             if dvl_grad is not None:


### PR DESCRIPTION
## Summary

This PR implements **causal masking** and passes it for the standard attention function.

## Changes

- Created a **causal mask** of shape `[1, 1, seq_len, seq_len]` using `torch.tril`.
- Applied the mask in the standard attention calculation (`apply_standard_attention`) to set attention scores for future tokens to `-inf`.
- Added debug logging to verify the effect of the mask:
  - Attention scores **before masking**  
  - Attention scores **after masking**  

### Log of Masking Effect

Scores BEFORE masking (10x10 slice):
tensor([[ 0.2949, 0.1639, -0.3008, ...]])
 Scores AFTER masking (10x10 slice):
tensor([[ 0.2949, -inf, -inf, ...]])

## Commit Reference

- [add causal masking support in step_attn](https://github.com/iCog-Labs-Dev/PC-Transformers/commit/640613fc37cc4bd0ed840708dadbf58772ac6483)

