### PR TITLE
Mitigating Token Frequency Bias in Local Updates

### DIFF
--- a/utils/pc_utils.py
+++ b/utils/pc_utils.py
@@ -57,13 +57,15 @@ def step_embed(
             
             # Frequency-Normalized Updates (In-Batch Mean Scaling)
             # This ensures that the update magnitude is independent of token frequency.
-            word_counts = torch.bincount(flat_input_ids, minlength=vocab_size)
-            pos_counts = torch.bincount(flat_position_ids, minlength=max_pos)
+            word_counts = torch.bincount(flat_input_ids, minlength=vocab_size).float().to(delta.device)
+            pos_counts = torch.bincount(flat_position_ids, minlength=max_pos).float().to(delta.device)
             
-            # Map counts back to flattened indices and normalize delta
-            # counts[flat_input_ids] gives the frequency of each token in the batch at its respective position
-            word_delta = delta / word_counts[flat_input_ids].unsqueeze(1).float()
-            pos_delta = delta / pos_counts[flat_position_ids].unsqueeze(1).float()
+            # Robustness: prevent division by zero and ensure correct mapping
+            word_counts = word_counts.clamp(min=1)
+            pos_counts = pos_counts.clamp(min=1)
+            
+            word_delta = delta / word_counts[flat_input_ids].unsqueeze(1)
+            pos_delta = delta / pos_counts[flat_position_ids].unsqueeze(1)
             
             word_layer.weight.data.index_add_(0, flat_input_ids, word_delta)
             pos_layer.weight.data.index_add_(0, flat_position_ids, pos_delta)

--- a/utils/pc_utils.py
+++ b/utils/pc_utils.py
@@ -55,8 +55,18 @@ def step_embed(
             delta = local_lr * flat_update
             delta = torch.clamp(delta, -0.01, 0.01)
             
-            word_layer.weight.data.index_add_(0, flat_input_ids, delta)
-            pos_layer.weight.data.index_add_(0, flat_position_ids, delta)
+            # Frequency-Normalized Updates (In-Batch Mean Scaling)
+            # This ensures that the update magnitude is independent of token frequency.
+            word_counts = torch.bincount(flat_input_ids, minlength=vocab_size)
+            pos_counts = torch.bincount(flat_position_ids, minlength=max_pos)
+            
+            # Map counts back to flattened indices and normalize delta
+            # counts[flat_input_ids] gives the frequency of each token in the batch at its respective position
+            word_delta = delta / word_counts[flat_input_ids].unsqueeze(1).float()
+            pos_delta = delta / pos_counts[flat_position_ids].unsqueeze(1).float()
+            
+            word_layer.weight.data.index_add_(0, flat_input_ids, word_delta)
+            pos_layer.weight.data.index_add_(0, flat_position_ids, pos_delta)
             
     if t == T - 1:
            finalize_step(mu, target, error, t, layer_type, energy_fn_name)


### PR DESCRIPTION
### Problem: Frequency Bias in Local Updates

In the PC Transformer, embedding updates were summed per batch, giving high-frequency words much larger updates than rare ones. This caused common words to collapse into tight clusters while rare words barely changed, biasing the model.

### Solution: Frequency-Normalized Updates

This PR  normalize updates by word frequency so each unique word gets a single “average” update per batch. Applied to both word and position embeddings, this ensures:

- Fairness: all words are updated equally.

- Stability: avoids exploding updates.

- Better scaling: rare words keep up with common ones.