### PR TITLE
Decompose Attention Mechanism into Granular Latent States (Query, Key, Value, Score, Attention Weights

### DIFF
--- a/model_architecture/attention.py
+++ b/model_architecture/attention.py
@@ -18,6 +18,9 @@ class Attention(nn.Module):
         self.q = nn.Linear(config.n_embed, config.n_embed)
         self.k = nn.Linear(config.n_embed, config.n_embed)
         self.v = nn.Linear(config.n_embed, config.n_embed)
+        # Decomposed attention latent projections
+        self.score = nn.Linear(config.n_embed, config.n_embed)
+        self.A = nn.Linear(config.n_embed, config.n_embed)
         self.output = nn.Linear(config.n_embed, config.n_embed)
 
         self.pc_qkv = PCLayer(

--- a/model_architecture/pc_t_model.py
+++ b/model_architecture/pc_t_model.py
@@ -4,7 +4,6 @@ from .embedding import Embedding_Layer
 from .transformer_block import TransformerBlock
 from utils.pc_utils import ids_to_one_hot
 from .output import OutputLayer
-from utils.device_utils import create_streams_or_futures, execute_parallel, synchronize_execution
 
 class PCTransformer(nn.Module):
     """
@@ -28,7 +27,8 @@ class PCTransformer(nn.Module):
         This enables lateral connections for local learning in each layer.
         """
         for block in self.blocks:
-            block.attn.pc_qkv.register_lateral("attn", block.attn.q.in_features)
+            for lt in ["x_query", "x_key", "x_value", "x_score", "x_A"]:
+                block.attn.pc_qkv.register_lateral(lt, block.attn.q.in_features)
             block.attn.pc_output.register_lateral("linear", block.attn.output.in_features)
             block.mlp.pc_layer1.register_lateral("fc1", block.mlp.fc1.in_features)
             block.mlp.pc_layer2.register_lateral("linear", block.mlp.fc2.in_features)
@@ -88,12 +88,52 @@ class PCTransformer(nn.Module):
             block.attn.pc_qkv.init_x(
                 batch_size=B,
                 seq_len=S,
-                layer_type="attn",
-                device = device,
-                layer = None,
-                proj_layers={"q_proj": block.attn.q, "k_proj": block.attn.k, "v_proj": block.attn.v},
-                input_ids = None,
-                position_ids = None,
+                layer_type="x_query",
+                device=device,
+                layer=block.attn.q,
+                proj_layers=None,
+                input_ids=None,
+                position_ids=None,
+            )
+            block.attn.pc_qkv.init_x(
+                batch_size=B,
+                seq_len=S,
+                layer_type="x_key",
+                device=device,
+                layer=block.attn.k,
+                proj_layers=None,
+                input_ids=None,
+                position_ids=None,
+            )
+            block.attn.pc_qkv.init_x(
+                batch_size=B,
+                seq_len=S,
+                layer_type="x_value",
+                device=device,
+                layer=block.attn.v,
+                proj_layers=None,
+                input_ids=None,
+                position_ids=None,
+            )
+            block.attn.pc_qkv.init_x(
+                batch_size=B,
+                seq_len=S,
+                layer_type="x_score",
+                device=device,
+                layer=block.attn.score,
+                proj_layers=None,
+                input_ids=None,
+                position_ids=None,
+            )
+            block.attn.pc_qkv.init_x(
+                batch_size=B,
+                seq_len=S,
+                layer_type="x_A",
+                device=device,
+                layer=block.attn.A,
+                proj_layers=None,
+                input_ids=None,
+                position_ids=None,
             )
             block.attn.pc_output.init_x(
                 batch_size=B,
@@ -136,36 +176,29 @@ class PCTransformer(nn.Module):
             position_ids = None,
         )
 
-        # Initialize streams or futures for parallel execution
-        use_cuda, streams_or_futures = create_streams_or_futures(device, len(self.blocks) * 4 + 2)
-
         for t in range(self.config.T):
             # Execute output layer
             td_mlp2 = self.blocks[-1].mlp.pc_layer2.get_td_err("fc2") if t > 0 else None
-            execute_parallel(
-                use_cuda,
-                streams_or_futures,
-                self.output.pc_layer.forward,
+            self.output.pc_layer.forward(
                 target_activity=target_logits,
                 layer_type="linear_output",
                 t=t,
                 T=self.config.T,
                 requires_update=True,
-                td_err= td_mlp2,
+                td_err=td_mlp2,
                 layer=self.output.output,
                 layer_norm=None,
                 proj_layers=None,
                 input_ids=None,
                 position_ids=None,
-                flash=False
-
+                flash=False,
             )
 
-            # Iterate through blocks in reverse order for parallel execution
+            # Iterate through blocks in reverse order (sequential to preserve dependencies)
             for idx in range(len(self.blocks) - 1, -1, -1):
                 block = self.blocks[idx]
                 next_target = (
-                    self.blocks[idx + 1].attn.pc_qkv.get_x("attn")
+                    self.blocks[idx + 1].attn.pc_qkv.get_x("x_query")
                     if idx < len(self.blocks) - 1
                     else self.output.pc_layer.get_x("linear_output")
                 )
@@ -176,120 +209,185 @@ class PCTransformer(nn.Module):
                 td_mlp1 = block.mlp.pc_layer1.get_td_err("fc1") if t > 0 else None
 
                 # Execute MLP layer 2
-                execute_parallel(
-                    use_cuda,
-                    streams_or_futures,
-                    block.mlp.pc_layer2.forward,
+                block.mlp.pc_layer2.forward(
                     target_activity=next_target,
                     layer_type="fc2",
                     t=t,
                     T=self.config.T,
                     requires_update=True,
-                    td_err= td_mlp1,
+                    td_err=td_mlp1,
                     layer=block.mlp.fc2,
                     layer_norm=layer_norm2,
                     proj_layers=None,
                     input_ids=None,
                     position_ids=None,
-                    flash=False
-
+                    flash=False,
                 )
+
                 td_attn_op = block.attn.pc_output.get_td_err("linear_attn") if t > 0 else None
 
                 # Execute MLP layer 1
-                execute_parallel(
-                    use_cuda,
-                    streams_or_futures,
-                    block.mlp.pc_layer1.forward,
+                block.mlp.pc_layer1.forward(
                     target_activity=block.mlp.pc_layer2.get_x("fc2"),
                     layer_type="fc1",
                     t=t,
                     T=self.config.T,
                     requires_update=True,
-                    td_err= td_attn_op,
+                    td_err=td_attn_op,
                     layer=block.mlp.fc1,
-                    layer_norm=block.ln1, 
+                    layer_norm=block.ln1,
                     proj_layers=None,
                     input_ids=None,
                     position_ids=None,
-                    flash=False
-
+                    flash=False,
                 )
                 
                 if idx == 0:
                    td_embed = self.embedding.pc_layer.get_td_err("embed") if t > 0 else None
                 else:
                    td_embed = self.blocks[idx - 1].mlp.pc_layer2.get_td_err("fc2") if t > 0 else None
-                
-                td_attn_qkv = block.attn.pc_qkv.get_td_err("attn") if t > 0 else None
 
-    
-                # Execute attention output
-                execute_parallel(
-                    use_cuda,
-                    streams_or_futures,
-                    block.attn.pc_output.forward,
+                # linear_attn td_err comes from {x_A, x_value} (previous iteration)
+                td_x_A = block.attn.pc_qkv.get_td_err("x_A") if t > 0 else None
+                td_x_value = block.attn.pc_qkv.get_td_err("x_value") if t > 0 else None
+                td_linear_attn = None
+                if td_x_A is not None and td_x_value is not None:
+                    td_linear_attn = 0.5 * (td_x_A + td_x_value)
+                elif td_x_A is not None:
+                    td_linear_attn = td_x_A
+                elif td_x_value is not None:
+                    td_linear_attn = td_x_value
+
+                # Execute attention output (linear_attn)
+                block.attn.pc_output.forward(
                     target_activity=block.mlp.pc_layer1.get_x("fc1"),
                     layer_type="linear_attn",
                     t=t,
                     T=self.config.T,
                     requires_update=True,
-                    td_err= td_attn_qkv,
-                    layer=block.attn.output, 
+                    td_err=td_linear_attn,
+                    layer=block.attn.output,
                     layer_norm=block.ln1,
                     proj_layers=None,
                     input_ids=None,
                     position_ids=None,
-                    flash=False
-
+                    flash=False,
                 )
 
-                # Execute attention QKV
-                execute_parallel(
-                    use_cuda,
-                    streams_or_futures,
-                    block.attn.pc_qkv.forward,
+                # x_value target linear_attn, td_error from embed
+                block.attn.pc_qkv.forward(
                     target_activity=block.attn.pc_output.get_x("linear_attn"),
-                    layer_type="attn",
+                    layer_type="x_value",
                     t=t,
                     T=self.config.T,
                     requires_update=True,
-                    td_err= td_embed,
-                    layer = None,
+                    td_err=td_embed,
+                    layer=block.attn.v,
                     layer_norm=block.ln2,
-                    proj_layers={"q_proj": block.attn.q, "k_proj": block.attn.k, "v_proj": block.attn.v},
+                    proj_layers=None,
                     input_ids=None,
                     position_ids=None,
-                    flash=getattr(self.config, 'use_flash_attention', False),
-                    use_cache=use_kv_cache,  
-                    kv_cache=block.attn.kv_cache if use_kv_cache else None, 
+                    flash=False,
+                    use_cache=use_kv_cache,
+                    kv_cache=block.attn.kv_cache if use_kv_cache else None,
+                )
+
+                # x_query target x_score, td_error from embed
+                block.attn.pc_qkv.forward(
+                    target_activity=block.attn.pc_qkv.get_x("x_score"),
+                    layer_type="x_query",
+                    t=t,
+                    T=self.config.T,
+                    requires_update=True,
+                    td_err=td_embed,
+                    layer=block.attn.q,
+                    layer_norm=block.ln2,
+                    proj_layers=None,
+                    input_ids=None,
+                    position_ids=None,
+                    flash=False,
+                )
+
+                # x_key target x_score, td_error from embed
+                block.attn.pc_qkv.forward(
+                    target_activity=block.attn.pc_qkv.get_x("x_score"),
+                    layer_type="x_key",
+                    t=t,
+                    T=self.config.T,
+                    requires_update=True,
+                    td_err=td_embed,
+                    layer=block.attn.k,
+                    layer_norm=block.ln2,
+                    proj_layers=None,
+                    input_ids=None,
+                    position_ids=None,
+                    flash=False,
+                    use_cache=use_kv_cache,
+                    kv_cache=block.attn.kv_cache if use_kv_cache else None,
+                )
+
+                # x_score target x_A, td_error from {x_query, x_key} (previous iteration)
+                td_x_query = block.attn.pc_qkv.get_td_err("x_query") if t > 0 else None
+                td_x_key = block.attn.pc_qkv.get_td_err("x_key") if t > 0 else None
+                td_x_score = None
+                if td_x_query is not None and td_x_key is not None:
+                    td_x_score = 0.5 * (td_x_query + td_x_key)
+                elif td_x_query is not None:
+                    td_x_score = td_x_query
+                elif td_x_key is not None:
+                    td_x_score = td_x_key
+
+                block.attn.pc_qkv.forward(
+                    target_activity=block.attn.pc_qkv.get_x("x_A"),
+                    layer_type="x_score",
+                    t=t,
+                    T=self.config.T,
+                    requires_update=True,
+                    td_err=td_x_score,
+                    layer=block.attn.score,
+                    layer_norm=block.ln2,
+                    proj_layers=None,
+                    input_ids=None,
+                    position_ids=None,
+                    flash=False,
+                )
+
+                # x_A target linear_attn, td_error from x_score (previous iteration)
+                td_from_x_score = block.attn.pc_qkv.get_td_err("x_score") if t > 0 else None
+                block.attn.pc_qkv.forward(
+                    target_activity=block.attn.pc_output.get_x("linear_attn"),
+                    layer_type="x_A",
+                    t=t,
+                    T=self.config.T,
+                    requires_update=True,
+                    td_err=td_from_x_score,
+                    layer=block.attn.A,
+                    layer_norm=block.ln2,
+                    proj_layers=None,
+                    input_ids=None,
+                    position_ids=None,
+                    flash=False,
                 )
 
                 # Update cache after last iteration
                 if use_kv_cache and t == self.config.T - 1:
                     block.attn.kv_cache = block.attn.pc_qkv._last_kv_cache
     
-            # Execute embedding layer
-            execute_parallel(
-                use_cuda,
-                streams_or_futures,
-                self.embedding.pc_layer.forward,
-                target_activity=self.blocks[0].attn.pc_qkv.get_x("attn"),
+            # Execute embedding layer (provides td_err used by x_query/x_key/x_value)
+            self.embedding.pc_layer.forward(
+                target_activity=self.blocks[0].attn.pc_qkv.get_x("x_query"),
                 layer_type="embed",
                 t=t,
                 T=self.config.T,
                 requires_update=True,
-                td_err = None,
+                td_err=None,
                 layer={"word": self.embedding.word_embeddings, "pos": self.embedding.position_embeddings},
-                layer_norm= block.ln2,
+                layer_norm=self.blocks[0].ln2,
                 proj_layers=None,
                 input_ids=input_ids,
                 position_ids=position_ids,
-                flash=False
+                flash=False,
             )
-
-            # Synchronize all parallel tasks
-            synchronize_execution(use_cuda, streams_or_futures)
         logits = self.output.pc_layer.get_mu("linear_output")
         return logits
     

--- a/predictive_coding/pc_layer.py
+++ b/predictive_coding/pc_layer.py
@@ -6,7 +6,11 @@ from utils.pc_utils import (
     x_init,
     step_embed,
     step_linear,
-    step_attn,
+    step_x_query,
+    step_x_key,
+    step_x_value,
+    step_x_score,
+    step_x_A,
     finalize_step,
 )
 from utils.optim.optim_utils import PCOptimizer
@@ -15,7 +19,7 @@ from predictive_coding.lateral_connc import LateralConnections
 class PCLayer(nn.Module):
     """
     Predictive Coding Layer wrapper that manages iterative inference state and
-    delegates computation to helper functions (step_embed, step_attn, step_linear).
+    delegates computation to helper functions (step_embed, decomposed attention steps, step_linear).
     """
     def __init__(
         self,
@@ -57,6 +61,7 @@ class PCLayer(nn.Module):
         self._error_cache: Dict[str, torch.Tensor] = {}
         self._energy = 0.0
         self._errors = []
+        self._last_kv_cache: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
     
     def register_lateral(self, layer_type: str, size: int):
         """Create and register lateral connections for layer_type."""
@@ -120,34 +125,131 @@ class PCLayer(nn.Module):
             self._energy += energy
             self._errors.extend(step_errors)
             return mu_word, mu_pos
-        
-        elif layer_type == "attn":
+
+        elif layer_type in {"x_query", "x_key", "x_value"}:
             lateral_conn = self.lateral_connections.get(layer_type, None)
-            x, mu, bu_err, new_kv_cache = step_attn(
+            if layer is None:
+                raise ValueError(f"layer must be provided for layer_type={layer_type}")
+
+            if layer_type == "x_query":
+                x, mu, bu_err = step_x_query(
+                    t,
+                    T,
+                    target_activity,
+                    x,
+                    layer,
+                    lateral_conn,
+                    layer_type,
+                    self.local_lr,
+                    self.clamp_value,
+                    self.energy_fn_name,
+                    self.update_bias,
+                    requires_update,
+                    td_err=td_err,
+                    layer_norm=layer_norm,
+                    optimizer=self.optimizer,
+                )
+            elif layer_type == "x_key":
+                x, mu, bu_err = step_x_key(
+                    t,
+                    T,
+                    target_activity,
+                    x,
+                    layer,
+                    lateral_conn,
+                    layer_type,
+                    self.local_lr,
+                    self.clamp_value,
+                    self.energy_fn_name,
+                    self.update_bias,
+                    requires_update,
+                    td_err=td_err,
+                    layer_norm=layer_norm,
+                    optimizer=self.optimizer,
+                )
+            else:
+                x, mu, bu_err = step_x_value(
+                    t,
+                    T,
+                    target_activity,
+                    x,
+                    layer,
+                    lateral_conn,
+                    layer_type,
+                    self.local_lr,
+                    self.clamp_value,
+                    self.energy_fn_name,
+                    self.update_bias,
+                    requires_update,
+                    td_err=td_err,
+                    layer_norm=layer_norm,
+                    optimizer=self.optimizer,
+                )
+
+            # KV cache support: treat mu of x_key/x_value as K/V
+            if use_cache and layer_type in {"x_key", "x_value"}:
+                cached_k, cached_v = kv_cache if kv_cache is not None else (None, None)
+                # If we already updated partial cache this step, prefer it
+                if self._last_kv_cache is not None:
+                    cached_k = self._last_kv_cache[0] if self._last_kv_cache[0] is not None else cached_k
+                    cached_v = self._last_kv_cache[1] if self._last_kv_cache[1] is not None else cached_v
+
+                if layer_type == "x_key":
+                    new_k = mu.detach()
+                    k_total = torch.cat([cached_k, new_k], dim=1) if cached_k is not None else new_k
+                    self._last_kv_cache = (k_total, cached_v)
+                else:
+                    new_v = mu.detach()
+                    v_total = torch.cat([cached_v, new_v], dim=1) if cached_v is not None else new_v
+                    self._last_kv_cache = (cached_k, v_total)
+
+        elif layer_type == "x_score":
+            lateral_conn = self.lateral_connections.get(layer_type, None)
+            if layer is None:
+                raise ValueError("x_score requires a layer (weights/bias)")
+            x, mu, bu_err = step_x_score(
                 t,
                 T,
                 target_activity,
                 x,
+                layer,
                 lateral_conn,
-                proj_layers,
                 layer_type,
                 self.local_lr,
                 self.clamp_value,
                 self.energy_fn_name,
                 self.update_bias,
                 requires_update,
-                self.num_heads,
-                self.n_embed,
-                td_err=td_err, 
+                td_err=td_err,
                 layer_norm=layer_norm,
-                flash=flash, 
-                kv_cache=kv_cache,  
-                use_cache=use_cache,
                 optimizer=self.optimizer,
             )
-            # Store cache for retrieval
-            if use_cache:
-                self._last_kv_cache = new_kv_cache
+
+        elif layer_type == "x_A":
+            lateral_conn = self.lateral_connections.get(layer_type, None)
+            x_score = self._x_cache.get("x_score", None)
+            if layer is None:
+                raise ValueError("x_A requires a layer (weights/bias)")
+            if x_score is None:
+                raise ValueError("x_A requires cached x from x_score")
+            x, mu, bu_err = step_x_A(
+                t,
+                T,
+                target_activity,
+                x,
+                layer,
+                lateral_conn,
+                layer_type,
+                self.local_lr,
+                self.clamp_value,
+                self.energy_fn_name,
+                self.update_bias,
+                requires_update,
+                x_score=x_score,
+                td_err=td_err,
+                layer_norm=layer_norm,
+                optimizer=self.optimizer,
+            )
         
         else:
             lateral_conn = self.lateral_connections.get(layer_type, None)
@@ -197,7 +299,7 @@ class PCLayer(nn.Module):
         """
         Initialize cached activity `x` for the layer type.
         - embed: stores (x_word, x_pos) from embedding weights
-        - attn: creates random initialization shaped (B, S, H_out)
+        - x_query/x_key/x_value/x_score/x_A: random init shaped (B, S, n_embed)
         - linear/others: random init sized to layer input dimension
         """
         if layer_type == "embed":
@@ -213,16 +315,21 @@ class PCLayer(nn.Module):
             x_word = layer["word"].weight[input_ids] 
             x_pos = layer["pos"].weight[position_ids] 
             self._x_cache["embed"] = (x_word, x_pos)
-            
-        elif layer_type == "attn":
-            assert proj_layers is not None, "Attention layer requires proj_layers"
-            H_in = proj_layers["q_proj"].weight.shape[1]
-            H_out = proj_layers["v_proj"].weight.shape[0] 
-            self._x_cache["attn"] = x_init(batch_size, seq_len, H_out, device)
-            
-            self.register_lateral(layer_type, H_in)
+
+        elif layer_type in {"x_query", "x_key", "x_value", "x_score", "x_A"}:
+            if layer is not None:
+                input_dim = layer.weight.shape[1]
+            elif self.n_embed is not None:
+                input_dim = int(self.n_embed)
+            elif proj_layers is not None and "q_proj" in proj_layers:
+                input_dim = proj_layers["q_proj"].weight.shape[1]
+            else:
+                raise ValueError("Attention sub-layer init requires layer or n_embed")
+
+            self._x_cache[layer_type] = x_init(batch_size, seq_len, input_dim, device)
+            self.register_lateral(layer_type, input_dim)
             if layer_type in self.lateral_connections:
-                self.lateral_connections[layer_type] = self.lateral_connections[layer_type].to(device) 
+                self.lateral_connections[layer_type] = self.lateral_connections[layer_type].to(device)
         
         else:  
             assert layer is not None, "Linear layer requires layer parameter"

--- a/utils/pc_utils.py
+++ b/utils/pc_utils.py
@@ -10,6 +10,21 @@ def x_init(batch_size: int, seq_len: int, embedding_size: int, device: torch.dev
     device = device or (torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu"))
     return torch.randn(batch_size, seq_len, embedding_size, device = device)
 
+def init_x_query(batch_size: int, seq_len: int, n_embed: int, device: torch.device = None) -> torch.Tensor:
+    return x_init(batch_size, seq_len, n_embed, device)
+
+def init_x_key(batch_size: int, seq_len: int, n_embed: int, device: torch.device = None) -> torch.Tensor:
+    return x_init(batch_size, seq_len, n_embed, device)
+
+def init_x_value(batch_size: int, seq_len: int, n_embed: int, device: torch.device = None) -> torch.Tensor:
+    return x_init(batch_size, seq_len, n_embed, device)
+
+def init_x_score(batch_size: int, seq_len: int, n_embed: int, device: torch.device = None) -> torch.Tensor:
+    return x_init(batch_size, seq_len, n_embed, device)
+
+def init_x_A(batch_size: int, seq_len: int, n_embed: int, device: torch.device = None) -> torch.Tensor:
+    return x_init(batch_size, seq_len, n_embed, device)
+
 def step_embed(
     t: int,
     T: int,
@@ -151,163 +166,277 @@ def step_linear(
 
     return x, mu, bu_err
 
-def step_attn(
+def _step_projected_latent(
+    *,
     t: int,
     T: int,
     target: torch.Tensor,
     x: torch.Tensor,
-    lateral_conn: Optional[Any],
-    proj_layers: dict,
+    layer: nn.Linear,
+    lateral_conn: Any,
     layer_type: str,
     local_lr: float,
     clamp_value: float,
     energy_fn_name: str,
     update_bias: bool,
     requires_update: bool,
-    num_heads: int,
-    n_embed: int,
     td_err: Optional[torch.Tensor],
     layer_norm: Optional[nn.Module],
-    flash: bool = False,
-    kv_cache: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
-    use_cache: bool = False,
-    optimizer: Optional[PCOptimizer] = None,
-    ):
-    """
-    Predictive coding step for attention with KV caching support.
-    Returns (updated_x, mu, bu_err).
-    - proj_layers must contain 'q_proj','k_proj','v_proj' modules
-    """
-    assert proj_layers is not None, "proj_layers dict is required for attention"
+    optimizer: Optional[PCOptimizer],
+):
+    x_input = layer_norm(x) if layer_norm is not None else x
+    mu = layer(x_input)
+    bu_err = target - mu
 
-    device = x.device
-    
-    x_norm=layer_norm(x) if layer_norm is not None else x
-        
-    q_proj = proj_layers["q_proj"]
-    k_proj = proj_layers["k_proj"]
-    v_proj = proj_layers["v_proj"]
-    assert q_proj is not None and k_proj is not None and v_proj is not None, "Missing Q/K/V projections"  
-        
-    batch_size, seq_len, embed_dim = target.shape
-    head_dim = n_embed // num_heads
-   
-    Q= q_proj(x_norm)
-    
-    # KV Cache logic: only compute K,V for new tokens if cache exists
-    if use_cache and kv_cache is not None:
-        K_new = k_proj(x_norm)
-        V_new = v_proj(x_norm)
-        
-        K_cached, V_cached = kv_cache
-        K = torch.cat([K_cached, K_new], dim=1)
-        V = torch.cat([V_cached, V_new], dim=1)
-    else:
-        # Compute full K, V
-        K = k_proj(x_norm)
-        V = v_proj(x_norm)
-    
-    new_kv_cache = (K.detach(), V.detach()) if use_cache else None
-    Q = Q.view(batch_size, num_heads, seq_len, head_dim)
-    K = K.view(batch_size, num_heads, -1, head_dim)
-    V = V.view(batch_size, num_heads, -1, head_dim)
-        
-    #create causal mask (1=keep, 0=mask)
-    kv_len = K.size(2)
-    causal_mask = torch.tril(torch.ones(seq_len, kv_len, device=device)).unsqueeze(0).unsqueeze(0)
+    error_proj = bu_err @ layer.weight
+    error = error_proj - td_err if td_err is not None else error_proj
 
-    # !! Causal Mask
-    if flash:
-        mu_heads = apply_flash_attention(Q, K, V, mask=causal_mask)
-    else:
-        mu_heads = apply_standard_attention(Q, K, V, mask=causal_mask)
-    
-    mu = mu_heads.transpose(1, 2).contiguous().view(batch_size, seq_len, embed_dim)
-    
-    bu_err = target - mu  # B, T, D
-    error = bu_err - td_err if td_err is not None else bu_err  
-                
-    if lateral_conn is not None:
-        delta_x = lateral_conn.forward(x, error)
-        x = x + local_lr * delta_x
-        
-        if requires_update:
-            lateral_conn.update_weights(x.detach(), optimizer=optimizer, clamp_value=clamp_value)
-    else:
-        x = x + local_lr * error
+    # Always use lateral connections when updating
+    if lateral_conn is None:
+        raise ValueError(f"Lateral connection is required for layer_type={layer_type}")
+
+    delta_x = lateral_conn.forward(x, error)
+    x = x + local_lr * delta_x
+    if requires_update:
+        lateral_conn.update_weights(x.detach(), optimizer=optimizer, clamp_value=0.01)
 
     x = torch.clamp(x, -abs(clamp_value), abs(clamp_value))
 
-    # PC update W_latent
     if requires_update:
-        with torch.no_grad():
-            B, S = batch_size, seq_len
+        update_w = torch.einsum("bsv, bsh -> vh", bu_err, x_input.detach())
+        if optimizer is not None:
+            optimizer.step_param(layer.weight, update_w, local_lr, clamp_value=0.01)
+        else:
+            layer.weight.data.add_(torch.clamp(local_lr * update_w, -0.01, 0.01))
 
-            K_update = K[:, :, -seq_len:, :]
-            V_update = V[:, :, -seq_len:, :]
-
-            update_q = torch.zeros_like(q_proj.weight)
-            update_k = torch.zeros_like(k_proj.weight)
-            update_v = torch.zeros_like(v_proj.weight)
-
-            update_b_q = torch.zeros_like(q_proj.bias) if q_proj.bias is not None else None
-            update_b_k = torch.zeros_like(k_proj.bias) if k_proj.bias is not None else None
-            update_b_v = torch.zeros_like(v_proj.bias) if v_proj.bias is not None else None
-
-            # Multi-head Q, K, V updates
-            for h in range(num_heads):
-                q_slice = Q[:, h, :, :]  # [B, S, head_dim]
-                k_slice = K_update[:, h, :, :]
-                v_slice = V_update[:, h, :, :]
-
-                dW_q_h = torch.einsum("bsd,bse->de", q_slice, x_norm) / (B * S)
-                dW_k_h = torch.einsum("bsd,bse->de", k_slice, x_norm) / (B * S)
-                dW_v_h = torch.einsum("bsd,bse->de", v_slice, x_norm) / (B * S)
-
-                start = h * head_dim
-                end = (h + 1) * head_dim
-
-                update_q[start:end, :] = dW_q_h
-                update_k[start:end, :] = dW_k_h
-                update_v[start:end, :] = dW_v_h
-
-                if update_bias:
-                    if update_b_q is not None:
-                        update_b_q[start:end] = q_slice.mean(dim=(0, 1)) / (B * S)
-                    if update_b_k is not None:
-                        update_b_k[start:end] = k_slice.mean(dim=(0, 1)) / (B * S)
-                    if update_b_v is not None:
-                        update_b_v[start:end] = v_slice.mean(dim=(0, 1)) / (B * S)
-
+        if layer.bias is not None and update_bias:
+            update_b = bu_err.mean(dim=(0, 1))
             if optimizer is not None:
-                optimizer.step_param(q_proj.weight, update_q, local_lr, clamp_value=clamp_value)
-                optimizer.step_param(k_proj.weight, update_k, local_lr, clamp_value=clamp_value)
-                optimizer.step_param(v_proj.weight, update_v, local_lr, clamp_value=clamp_value)
-
-                if update_bias:
-                    if update_b_q is not None:
-                        optimizer.step_param(q_proj.bias, update_b_q, local_lr, clamp_value=clamp_value)
-                    if update_b_k is not None:
-                        optimizer.step_param(k_proj.bias, update_b_k, local_lr, clamp_value=clamp_value)
-                    if update_b_v is not None:
-                        optimizer.step_param(v_proj.bias, update_b_v, local_lr, clamp_value=clamp_value)
+                optimizer.step_param(layer.bias, update_b, local_lr, clamp_value=0.01)
             else:
-                q_proj.weight.data.add_(torch.clamp(local_lr * update_q, -clamp_value, clamp_value))
-                k_proj.weight.data.add_(torch.clamp(local_lr * update_k, -clamp_value, clamp_value))
-                v_proj.weight.data.add_(torch.clamp(local_lr * update_v, -clamp_value, clamp_value))
+                layer.bias.data.add_(torch.clamp(local_lr * update_b, -0.01, 0.01))
 
-                if update_bias:
-                    if update_b_q is not None:
-                        q_proj.bias.data.add_(torch.clamp(local_lr * update_b_q, -clamp_value, clamp_value))
-                    if update_b_k is not None:
-                        k_proj.bias.data.add_(torch.clamp(local_lr * update_b_k, -clamp_value, clamp_value))
-                    if update_b_v is not None:
-                        v_proj.bias.data.add_(torch.clamp(local_lr * update_b_v, -clamp_value, clamp_value))
- 
     if t == T - 1:
-        finalize_step(mu, target, error, t, layer_type,energy_fn_name)
-     
-    return x, mu, bu_err, new_kv_cache
+        finalize_step(mu, target, bu_err, t, layer_type, energy_fn_name)
+
+    return x, mu, bu_err
+
+
+def step_x_query(
+    t: int,
+    T: int,
+    target: torch.Tensor,
+    x: torch.Tensor,
+    layer: nn.Linear,
+    lateral_conn: Any,
+    layer_type: str,
+    local_lr: float,
+    clamp_value: float,
+    energy_fn_name: str,
+    update_bias: bool,
+    requires_update: bool,
+    td_err: Optional[torch.Tensor],
+    layer_norm: Optional[nn.Module],
+    optimizer: Optional[PCOptimizer] = None,
+):
+    return _step_projected_latent(
+        t=t,
+        T=T,
+        target=target,
+        x=x,
+        layer=layer,
+        lateral_conn=lateral_conn,
+        layer_type=layer_type,
+        local_lr=local_lr,
+        clamp_value=clamp_value,
+        energy_fn_name=energy_fn_name,
+        update_bias=update_bias,
+        requires_update=requires_update,
+        td_err=td_err,
+        layer_norm=layer_norm,
+        optimizer=optimizer,
+    )
+
+
+def step_x_key(
+    t: int,
+    T: int,
+    target: torch.Tensor,
+    x: torch.Tensor,
+    layer: nn.Linear,
+    lateral_conn: Any,
+    layer_type: str,
+    local_lr: float,
+    clamp_value: float,
+    energy_fn_name: str,
+    update_bias: bool,
+    requires_update: bool,
+    td_err: Optional[torch.Tensor],
+    layer_norm: Optional[nn.Module],
+    optimizer: Optional[PCOptimizer] = None,
+):
+    return _step_projected_latent(
+        t=t,
+        T=T,
+        target=target,
+        x=x,
+        layer=layer,
+        lateral_conn=lateral_conn,
+        layer_type=layer_type,
+        local_lr=local_lr,
+        clamp_value=clamp_value,
+        energy_fn_name=energy_fn_name,
+        update_bias=update_bias,
+        requires_update=requires_update,
+        td_err=td_err,
+        layer_norm=layer_norm,
+        optimizer=optimizer,
+    )
+
+
+def step_x_value(
+    t: int,
+    T: int,
+    target: torch.Tensor,
+    x: torch.Tensor,
+    layer: nn.Linear,
+    lateral_conn: Any,
+    layer_type: str,
+    local_lr: float,
+    clamp_value: float,
+    energy_fn_name: str,
+    update_bias: bool,
+    requires_update: bool,
+    td_err: Optional[torch.Tensor],
+    layer_norm: Optional[nn.Module],
+    optimizer: Optional[PCOptimizer] = None,
+):
+    return _step_projected_latent(
+        t=t,
+        T=T,
+        target=target,
+        x=x,
+        layer=layer,
+        lateral_conn=lateral_conn,
+        layer_type=layer_type,
+        local_lr=local_lr,
+        clamp_value=clamp_value,
+        energy_fn_name=energy_fn_name,
+        update_bias=update_bias,
+        requires_update=requires_update,
+        td_err=td_err,
+        layer_norm=layer_norm,
+        optimizer=optimizer,
+    )
+
+
+def step_x_score(
+    t: int,
+    T: int,
+    target: torch.Tensor,
+    x: torch.Tensor,
+    layer: nn.Linear,
+    lateral_conn: Any,
+    layer_type: str,
+    local_lr: float,
+    clamp_value: float,
+    energy_fn_name: str,
+    update_bias: bool,
+    requires_update: bool,
+    td_err: Optional[torch.Tensor],
+    layer_norm: Optional[nn.Module] = None,
+    optimizer: Optional[PCOptimizer] = None,
+):
+    x_input = layer_norm(x) if layer_norm is not None else x
+    mu = layer(x_input)
+    bu_err = target - mu
+
+    error_proj = bu_err @ layer.weight
+    error = error_proj - td_err if td_err is not None else error_proj
+
+    if lateral_conn is None:
+        raise ValueError(f"Lateral connection is required for layer_type={layer_type}")
+
+    delta_x = lateral_conn.forward(x, error)
+    x = x + local_lr * delta_x
+    if requires_update:
+        lateral_conn.update_weights(x.detach(), optimizer=optimizer, clamp_value=0.01)
+
+    x = torch.clamp(x, -abs(clamp_value), abs(clamp_value))
+
+    if requires_update:
+        update_w = torch.einsum("bsv, bsh -> vh", bu_err, x_input.detach())
+        if optimizer is not None:
+            optimizer.step_param(layer.weight, update_w, local_lr, clamp_value=0.01)
+        else:
+            layer.weight.data.add_(torch.clamp(local_lr * update_w, -0.01, 0.01))
+
+        if layer.bias is not None and update_bias:
+            update_b = bu_err.mean(dim=(0, 1))
+            if optimizer is not None:
+                optimizer.step_param(layer.bias, update_b, local_lr, clamp_value=0.01)
+            else:
+                layer.bias.data.add_(torch.clamp(local_lr * update_b, -0.01, 0.01))
+
+    if t == T - 1:
+        finalize_step(mu, target, bu_err, t, layer_type, energy_fn_name)
+    return x, mu, bu_err
+
+
+def step_x_A(
+    t: int,
+    T: int,
+    target: torch.Tensor,
+    x: torch.Tensor,
+    layer: nn.Linear,
+    lateral_conn: Any,
+    layer_type: str,
+    local_lr: float,
+    clamp_value: float,
+    energy_fn_name: str,
+    update_bias: bool,
+    requires_update: bool,
+    x_score: torch.Tensor,
+    td_err: Optional[torch.Tensor],
+    layer_norm: Optional[nn.Module] = None,
+    optimizer: Optional[PCOptimizer] = None,
+):
+    # step_x_A: x is initialized/overwritten as softmax(x_score) (as requested)
+    x = torch.softmax(x_score, dim=-1)
+    x_input = layer_norm(x) if layer_norm is not None else x
+    mu = layer(x_input)
+    bu_err = target - mu
+
+    error_proj = bu_err @ layer.weight
+    error = error_proj - td_err if td_err is not None else error_proj
+
+    if lateral_conn is None:
+        raise ValueError(f"Lateral connection is required for layer_type={layer_type}")
+
+    delta_x = lateral_conn.forward(x, error)
+    x = x + local_lr * delta_x
+    if requires_update:
+        lateral_conn.update_weights(x.detach(), optimizer=optimizer, clamp_value=0.01)
+
+    x = torch.clamp(x, -abs(clamp_value), abs(clamp_value))
+
+    if requires_update:
+        update_w = torch.einsum("bsv, bsh -> vh", bu_err, x_input.detach())
+        if optimizer is not None:
+            optimizer.step_param(layer.weight, update_w, local_lr, clamp_value=0.01)
+        else:
+            layer.weight.data.add_(torch.clamp(local_lr * update_w, -0.01, 0.01))
+
+        if layer.bias is not None and update_bias:
+            update_b = bu_err.mean(dim=(0, 1))
+            if optimizer is not None:
+                optimizer.step_param(layer.bias, update_b, local_lr, clamp_value=0.01)
+            else:
+                layer.bias.data.add_(torch.clamp(local_lr * update_b, -0.01, 0.01))
+
+    if t == T - 1:
+        finalize_step(mu, target, bu_err, t, layer_type, energy_fn_name)
+    return x, mu, bu_err
     
 ENERGY_FUNCTIONS = {
     "pc_e": lambda mu, x: ((mu - x) ** 2) * 0.5,    


### PR DESCRIPTION
<img width="1246" height="471" alt="Screenshot 2026-02-15 171046" src="https://github.com/user-attachments/assets/aa035a1c-7d5f-45c4-9d20-64e6f0f1dad3" />
<img width="1000" height="500" alt="energy_plot (5)" src="https://github.com/user-attachments/assets/eb43a060-400c-4ea1-91ea-7b199fff04f7" />
<img width="1000" height="500" alt="perplexity_plot (5)" src="https://github.com/user-attachments/assets/55956344-160c-4e3f-83d0-9c2671e4fc04" />
This PR refactors the monolithic attn layer within the Predictive Coding framework. It decomposes the attention mechanism into five distinct latent state layers: x_query, x_key, x_value, x_score, and x_A. This granular approach allows for independent error calculation, lateral connectivity, and state updates for every stage of the attention mechanism, rather than treating the attention block as a single black box.

### **Key Changes**
**1. Refactoring pc_utils.py (Step Functions)** [4cea75a](https://github.com/iCog-Labs-Dev/PC-Transformers/pull/115/changes/4cea75a8332c09d537ce8ab5e53eff9314204fcc)


**Removed: The generalized step_attn function has been removed entirely.

Added: New, specialized step functions have been implemented to handle the dynamics of each decomposed layer:**
- step_x_query 
- step_x_key
- step_x_value 
- step_x_score
- step_x_A

Initialization: Added specific initialization functions (init_x_query, init_x_key, etc.) to properly set up the state tensors, weights, and biases for each specific sub-layer.

Softmax Logic: The step_x_A function now explicitly handles the Softmax relationship, where x_A is derived as the softmax of x_score.

**2. Updates to pc_layer.py (Layer Management)**[4cea75a](https://github.com/iCog-Labs-Dev/PC-Transformers/pull/115/changes/4cea75a8332c09d537ce8ab5e53eff9314204fcc)


- **Decomposition:** The PCLayer class no longer recognizes a generic attn layer type. It now includes specific branching logic (elif blocks) for x_query, x_key, x_value, x_score, and x_A to call their respective step functions.
**- Lateral Connections:** The update logic has been hardened to ensure lateral connections are always present and active when updates occur. This enforces local inhibitory/excitatory interactions for every granular state.
**- KV Cache Handling:** * The logic for KV caching has been moved to the specific x_key and x_value layers.
- Implemented a deferred cache update mechanism: when x passes through the layer to generate predictions (mu), the KV cache is not immediately stored. Instead, it is held in _last_kv_cache and only committed if use_cache is enabled at the end of the timestep.

**3. Error Routing & Top-Down Dynamics**[4cea75a](https://github.com/iCog-Labs-Dev/PC-Transformers/pull/115/changes/4cea75a8332c09d537ce8ab5e53eff9314204fcc)

The error propagation flow has been completely rewired to support the decomposed architecture. Top-down errors (td_error) and Targets are now routed as follows:

**x_query:**

- Target: x_score
- TD Error Source: Comes from the Embedding layer (td_embed).

**x_key:**

- Target: x_score
- TD Error Source: Comes from the Embedding layer (td_embed).

**x_value:**

- Target: linear_attn (the attention output)
- TD Error Source: Comes from the Embedding layer (td_embed).

**x_score:**

- Target: x_A (Attention Weights)
- TD Error Source: Aggregated from x_query and x_key errors.
**x_A:**

- Target: linear_attn
- TD Error Source: Comes from x_score.

**linear_attn (Output):**

- Target: fc1
- TD Error Source: Aggregated from x_A and x_value.

Implementation Details
x_A Calculation: x_A is mathematically defined as Softmax(x_score). The predictive coding step for x_A optimizes this relationship specifically.

Output Flow: The final linear output target flows into target_logits from fc2.

Initialization: Every sub-layer (x_score, x_A, etc.) is initialized as a full layer containing weights and biases, ensuring that even intermediate states like attention scores have learnable parameters and latent representations.



