### PR TITLE
Gradient computation for Attention and Output layer 

### DIFF
--- a/generate_text.py
+++ b/generate_text.py
@@ -38,10 +38,12 @@ def generate_text(model, config, input_ids, max_new_tokens, temperature, device 
     
     generated_tokens = []
     
+    # Process prompt once, then only feed last token
+    with torch.no_grad():
+        model(input_tensor, input_tensor, use_kv_cache=True)
+
+    current_input = input_tensor[:, -1:]  # S=1 always
     for step in range(max_new_tokens):
-        # For first token or with cache, pass full or last token
-        current_input = input_tensor[:, -config.block_size:] if input_tensor.size(1) > config.block_size else input_tensor
-      
         logits = model(current_input, current_input, use_kv_cache=use_cache)
         logits = logits[:, -1, :] / temperature
         probs = F.softmax(logits, dim=-1)

--- a/predictive_coding/pc_layer.py
+++ b/predictive_coding/pc_layer.py
@@ -83,7 +83,7 @@ class PCLayer(nn.Module):
 
 
         if layer_type == "embed":
-            mu, mu_word, mu_pos, bu_err = step_embed(
+            mu, mu_word, bu_err = step_embed(
                 t,
                 T,
                 target_activity,
@@ -97,7 +97,7 @@ class PCLayer(nn.Module):
                 layer_norm=layer_norm,
             )            
             # store for later retrieval
-            self._x_cache["embed"] = (mu_word, mu_pos)
+            self._x_cache["embed"] = (mu_word)
             self._mu_cache["embed"] = mu.detach().clone()
             if bu_err is not None:
                 self._error_cache["embed"] = bu_err.detach().clone()
@@ -107,7 +107,7 @@ class PCLayer(nn.Module):
             energy, step_errors = finalize_step(mu, target_activity, error, t, layer_type, self.energy_fn_name)
             self._energy += energy
             self._errors.extend(step_errors)
-            return mu_word, mu_pos
+            return mu_word
         
         elif layer_type == "attn":
             lateral_conn = self.lateral_connections.get(layer_type, None)

--- a/predictive_coding/pc_layer.py
+++ b/predictive_coding/pc_layer.py
@@ -26,6 +26,7 @@ class PCLayer(nn.Module):
         n_embed: Optional[int] = None,
     ):
         super().__init__()
+        self.rope_cache: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
         self.T = T
         self.local_lr = lr
         self.update_bias = update_bias
@@ -68,6 +69,7 @@ class PCLayer(nn.Module):
         proj_layers: Optional[dict] = None,
         input_ids: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.Tensor] = None,
+        rope_cache: Optional[Tuple[torch.Tensor, torch.Tensor]] = None, 
         flash: bool = False,
         kv_cache: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,  # ADD THIS
         use_cache: bool = False, 
@@ -75,6 +77,10 @@ class PCLayer(nn.Module):
         """Perform one predictive coding inference step."""
         self._reset_step_state()
         x = self._get_cached_state(layer_type)
+
+        if rope_cache is not None:
+            self.rope_cache = rope_cache
+
 
         if layer_type == "embed":
             mu, mu_word, mu_pos, bu_err = step_embed(
@@ -84,7 +90,6 @@ class PCLayer(nn.Module):
                 layer,
                 layer_type,
                 input_ids,
-                position_ids,
                 self.local_lr,
                 self.clamp_value,
                 self.energy_fn_name,
@@ -123,6 +128,7 @@ class PCLayer(nn.Module):
                 self.n_embed,
                 td_err=td_err, 
                 layer_norm=layer_norm,
+                rope_cache=self.rope_cache, 
                 flash=flash, 
                 kv_cache=kv_cache,  
                 use_cache=use_cache,

--- a/utils/attention_utils.py
+++ b/utils/attention_utils.py
@@ -69,4 +69,4 @@ def apply_standard_attention(q, k, v, mask=None):
     attn_weights = torch.softmax(attn_scores, dim=-1)
     attn_output = torch.matmul(attn_weights, v)
 
-    return attn_output
+    return attn_output, attn_weights, attn_scores

--- a/utils/pc_utils.py
+++ b/utils/pc_utils.py
@@ -9,6 +9,46 @@ def x_init(batch_size: int, seq_len: int, embedding_size: int, device: torch.dev
     device = device or (torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu"))
     return torch.randn(batch_size, seq_len, embedding_size, device = device)
 
+def precompute_freqs_cis_real(dim: int, end: int, theta: float = 10000.0):
+    """
+    Precompute RoPE cos/sin of shape [end, dim] for easy broadcasting.
+    """
+    freqs = 1.0 / (theta ** (torch.arange(0, dim, 2).float() / dim))
+    t = torch.arange(end).float()
+    freqs = torch.outer(t, freqs)  # [end, dim//2]
+
+    # Interleave to full dimension
+    cos = torch.zeros(end, dim)
+    sin = torch.zeros(end, dim)
+    cos[:, 0::2] = freqs.cos()
+    cos[:, 1::2] = freqs.cos()
+    sin[:, 0::2] = freqs.sin()
+    sin[:, 1::2] = freqs.sin()
+
+    return cos, sin
+
+
+def rotate_half(x: torch.Tensor) -> torch.Tensor:
+    """
+    Rotates half the hidden dims of the input.
+    Used for the RoPE 'real' implementation trick.
+    """
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+def apply_rotary_emb(xq: torch.Tensor, xk: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Apply rotary embeddings using the Sine-Cosine rewrite.
+    """
+    # Reshape cos/sin for broadcasting: [1, 1, seq_len, head_dim]
+    cos = cos.unsqueeze(0).unsqueeze(0)
+    sin = sin.unsqueeze(0).unsqueeze(0)
+    
+    xq_out = (xq * cos) + (rotate_half(xq) * sin)
+    xk_out = (xk * cos) + (rotate_half(xk) * sin)
+    return xq_out, xk_out
+
 def step_embed(
     t: int,
     T: int,
@@ -16,33 +56,25 @@ def step_embed(
     layer: dict,
     layer_type: str,
     input_ids: torch.Tensor,
-    position_ids: torch.Tensor,
     local_lr: float,
     clamp_value: float,
     energy_fn_name: str,
     requires_update: bool,
     layer_norm: Optional[nn.Module] = None,
-    )-> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Predictive coding step for embedding layer.
-    Returns (mu, mu_word, mu_pos, error)
+    Returns (mu, mu_word, error).
     """
     word_layer: nn.Embedding = layer["word"]
-    pos_layer: nn.Embedding = layer["pos"]
     
-    # clip ids
     vocab_size = word_layer.weight.size(0)
     if input_ids.max() >= vocab_size:
         input_ids = torch.clamp(input_ids, max=vocab_size-1)
-    max_pos = pos_layer.weight.size(0)
-    if position_ids.max() >= max_pos:
-        position_ids = torch.clamp(position_ids, max=max_pos-1)
          
     mu_word = word_layer(input_ids)
-    mu_pos = pos_layer(position_ids)
-        
-    mu = mu_word + mu_pos
-    mu_norm=layer_norm(mu) if layer_norm is not None else mu
+    mu = mu_word 
+    mu_norm = layer_norm(mu) if layer_norm is not None else mu
 
     error = target - mu_norm
         
@@ -50,19 +82,13 @@ def step_embed(
         with torch.no_grad():
             flat_input_ids = input_ids.reshape(-1)
             flat_update = error.reshape(-1, error.size(-1))
-            flat_position_ids = position_ids.reshape(-1)
-            
-            delta = local_lr * flat_update
-            delta = torch.clamp(delta, -0.01, 0.01)
-            
+            delta = torch.clamp(local_lr * flat_update, -0.01, 0.01)
             word_layer.weight.data.index_add_(0, flat_input_ids, delta)
-            pos_layer.weight.data.index_add_(0, flat_position_ids, delta)
             
     if t == T - 1:
            finalize_step(mu, target, error, t, layer_type, energy_fn_name)
-  
-    return mu, mu_word, mu_pos, error
-    
+    return mu, mu_word, None, error
+
 def step_linear(
     t: int,
     T: int,
@@ -97,23 +123,21 @@ def step_linear(
     elif layer_norm is not None and layer_type in ["linear_attn", "fc2"]:
         mu = layer_norm(mu)
             
-    if layer_type=="linear_output":
-        bu_err= target - F.softmax(mu, dim=-1) 
+    if layer_type == "linear_output":
+        bu_err = target - F.softmax(mu, dim=-1) 
     else:    
         bu_err = target - mu 
-        
+
     # project bottom-up error through weights
-    error_proj= bu_err @ layer.weight      
-    error = error_proj- td_err if td_err is not None else error_proj  
+    error_proj = bu_err @ layer.weight      
+    error = error_proj - td_err if td_err is not None else error_proj  
     
     if lateral_conn is not None:
-        delta_x = lateral_conn.forward(x, error)
-        x = x + local_lr * delta_x
-
+        x = x + local_lr * lateral_conn.forward(x, error)
         if requires_update:
             lateral_conn.update_weights(x.detach())
     else:
-        x= x + local_lr * error 
+        x = x + local_lr * error 
 
     x = torch.clamp(x, -abs(clamp_value), abs(clamp_value))
     
@@ -124,12 +148,10 @@ def step_linear(
         layer.weight.data.add_(delta_W)
         if layer.bias is not None and update_bias:
             delta_b = local_lr * bu_err.mean(dim=(0, 1))
-            delta_b = torch.clamp(delta_b, -0.01, 0.01)
-            layer.bias.data.add_(delta_b)
+            layer.bias.data.add_(torch.clamp(delta_b, -0.01, 0.01))
 
     if t == T - 1:
-        finalize_step(mu, target, error, t, layer_type,energy_fn_name)
-
+        finalize_step(mu, target, error, t, layer_type, energy_fn_name)
     return x, mu, bu_err
 
 def step_attn(
@@ -149,68 +171,70 @@ def step_attn(
     n_embed: int,
     td_err: Optional[torch.Tensor],
     layer_norm: Optional[nn.Module],
+    rope_cache: Tuple[torch.Tensor, torch.Tensor],
     flash: bool = False,
     kv_cache: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     use_cache: bool = False,
     ):
     """
-    Predictive coding step for attention with KV caching support.
-    Returns (updated_x, mu, bu_err).
+    Predictive coding step for attention using Sine-Cosine RoPE.
     - proj_layers must contain 'q_proj','k_proj','v_proj' modules
     """
     assert proj_layers is not None, "proj_layers dict is required for attention"
 
     device = x.device
-    
-    x_norm=layer_norm(x) if layer_norm is not None else x
-        
+    x_norm = layer_norm(x) if layer_norm is not None else x
+
     q_proj = proj_layers["q_proj"]
     k_proj = proj_layers["k_proj"]
     v_proj = proj_layers["v_proj"]
     assert q_proj is not None and k_proj is not None and v_proj is not None, "Missing Q/K/V projections"  
         
-    batch_size, seq_len, embed_dim = target.shape
+    B, S, E = target.shape
     head_dim = n_embed // num_heads
-   
-    Q= q_proj(x_norm)
-    
-    # KV Cache logic: only compute K,V for new tokens if cache exists
+
+    #RAW projections (USED FOR LEARNING)
+    Q_raw = q_proj(x_norm).view(B, num_heads, S, head_dim)
+    K_raw = k_proj(x_norm).view(B, num_heads, S, head_dim)
+    V_raw = v_proj(x_norm).view(B, num_heads, S, head_dim)
+
+    #ROTATED copies (USED FOR ATTENTION ONLY)
+    Q = Q_raw.clone()
+    K_new = K_raw.clone()
+    V_new = V_raw  
+
+    cos, sin = rope_cache
+    cos = cos.to(device)
+    sin = sin.to(device)
+
+    Q, K_new = apply_rotary_emb(Q, K_new, cos[:S], sin[:S])
+
+    #KV cache handling
     if use_cache and kv_cache is not None:
-        K_new = k_proj(x_norm)
-        V_new = v_proj(x_norm)
-        
         K_cached, V_cached = kv_cache
-        K = torch.cat([K_cached, K_new], dim=1)
-        V = torch.cat([V_cached, V_new], dim=1)
+        K = torch.cat([K_cached, K_new], dim=2)
+        V = torch.cat([V_cached, V_new], dim=2)
     else:
-        # Compute full K, V
-        K = k_proj(x_norm)
-        V = v_proj(x_norm)
-    
-    new_kv_cache = (K.detach(), V.detach()) if use_cache else None
-    Q = Q.view(batch_size, num_heads, seq_len, head_dim)
-    K = K.view(batch_size, num_heads, -1, head_dim)
-    V = V.view(batch_size, num_heads, -1, head_dim)
-        
-    #create causal mask (1=keep, 0=mask)
-    kv_len = K.size(2)
-    causal_mask = torch.tril(torch.ones(seq_len, kv_len, device=device)).unsqueeze(0).unsqueeze(0)
+        K, V = K_new, V_new
+
+    causal_mask = torch.tril(
+        torch.ones(S, K.size(2), device=device)
+    ).unsqueeze(0).unsqueeze(0)
 
     # !! Causal Mask
     if flash:
         mu_heads = apply_flash_attention(Q, K, V, mask=causal_mask)
     else:
         mu_heads = apply_standard_attention(Q, K, V, mask=causal_mask)
-    
-    mu = mu_heads.transpose(1, 2).contiguous().view(batch_size, seq_len, embed_dim)
-    
-    bu_err = target - mu  # B, T, D
-    error = bu_err - td_err if td_err is not None else bu_err  
-                
+
+    mu = mu_heads.transpose(1, 2).contiguous().view(B, S, E)
+
+    bu_err = target - mu
+    error = bu_err - td_err if td_err is not None else bu_err
+
+    # State update
     if lateral_conn is not None:
-        delta_x = lateral_conn.forward(x, error)
-        x = x + local_lr * delta_x
-        
+        x = x + local_lr * lateral_conn.forward(x, error)
         if requires_update:
             lateral_conn.update_weights(x.detach())
     else:
@@ -218,47 +242,29 @@ def step_attn(
 
     x = torch.clamp(x, -abs(clamp_value), abs(clamp_value))
 
-    # PC update W_latent
+    #PC WEIGHT UPDATE (RAW, PRE-RoPE)
     if requires_update:
         with torch.no_grad():
-            B, S = batch_size, seq_len
-
-            K_update = K[:, :, -seq_len:, :] 
-            V_update = V[:, :, -seq_len:, :]
-            
-            # Multi-head Q, K, V updates
             for h in range(num_heads):
-                q_slice = Q[:, h, :, :]  # [B, S, head_dim]
-                k_slice = K_update[:, h, :, :]
-                v_slice = V_update[:, h, :, :]
-                
-                dW_q_h = torch.einsum("bsd,bse->de", q_slice, x_norm) / (B * S)
-                dW_k_h = torch.einsum("bsd,bse->de", k_slice, x_norm) / (B * S)
-                dW_v_h = torch.einsum("bsd,bse->de", v_slice, x_norm) / (B * S)
+                qh = Q_raw[:, h]
+                kh = K_raw[:, h]
+                vh = V_raw[:, h]
 
-                start = h * head_dim
-                end = (h + 1) * head_dim
-                
-                q_proj.weight.data[start:end, :] += torch.clamp(local_lr * dW_q_h, -clamp_value, clamp_value)
-                k_proj.weight.data[start:end, :] += torch.clamp(local_lr * dW_k_h, -clamp_value, clamp_value)
-                v_proj.weight.data[start:end, :] += torch.clamp(local_lr * dW_v_h, -clamp_value, clamp_value)
-                
-                if update_bias:
-                    if q_proj.bias is not None:
-                        delta_b_q = (q_slice.mean(dim=(0, 1)) / (B * S))
-                        q_proj.bias.data[start:end] += torch.clamp(local_lr * delta_b_q, -clamp_value, clamp_value)
-                    if k_proj.bias is not None:
-                        delta_b_k = (k_slice.mean(dim=(0, 1)) / (B * S))
-                        k_proj.bias.data[start:end] += torch.clamp(local_lr * delta_b_k, -clamp_value, clamp_value)
-                    if v_proj.bias is not None:
-                        delta_b_v = (v_slice.mean(dim=(0, 1)) / (B * S))
-                        v_proj.bias.data[start:end] += torch.clamp(local_lr * delta_b_v, -clamp_value, clamp_value)
- 
+                dWq = torch.einsum("bsd,bse->de", qh, x_norm) / (B * S)
+                dWk = torch.einsum("bsd,bse->de", kh, x_norm) / (B * S)
+                dWv = torch.einsum("bsd,bse->de", vh, x_norm) / (B * S)
+
+                s, e = h * head_dim, (h + 1) * head_dim
+
+                q_proj.weight.data[s:e] += torch.clamp(local_lr * dWq, -clamp_value, clamp_value)
+                k_proj.weight.data[s:e] += torch.clamp(local_lr * dWk, -clamp_value, clamp_value)
+                v_proj.weight.data[s:e] += torch.clamp(local_lr * dWv, -clamp_value, clamp_value)
+
     if t == T - 1:
-        finalize_step(mu, target, error, t, layer_type,energy_fn_name)
-     
-    return x, mu, bu_err, new_kv_cache
-    
+        finalize_step(mu, target, error, t, layer_type, energy_fn_name)
+
+    return x, mu, bu_err, (K.detach(), V.detach()) if use_cache else None
+
 ENERGY_FUNCTIONS = {
     "pc_e": lambda mu, x: ((mu - x) ** 2) * 0.5,    
     "kld": lambda mu, x: torch.clamp(
@@ -266,7 +272,7 @@ ENERGY_FUNCTIONS = {
     ),
 }
 
-def energy_fn(mu: torch.Tensor, x: torch.Tensor,energy_fn_name: str) -> torch.Tensor:
+def energy_fn(mu: torch.Tensor, x: torch.Tensor, energy_fn_name: str) -> torch.Tensor:
     if energy_fn_name not in ENERGY_FUNCTIONS:
         raise ValueError(f"Unknown energy function: {energy_fn_name}. Choose from {list(ENERGY_FUNCTIONS.keys())}")
     return ENERGY_FUNCTIONS[energy_fn_name](mu, x)

--- a/utils/pc_utils.py
+++ b/utils/pc_utils.py
@@ -98,14 +98,20 @@ def step_linear(
         mu = layer_norm(mu)
             
     if layer_type=="linear_output":
-        bu_err= target - F.softmax(mu, dim=-1) 
+        p = F.softmax(mu, dim=-1) 
+        bu_err= target - p
+        dE_dp= -bu_err
+        inner = (dE_dp * p).sum(dim=-1, keepdim=True)
+        dE_dmu = p * (dE_dp - inner)
+        error_proj= dE_dmu @ layer.weight     # project bottom-up error through weights
+
     else:    
         bu_err = target - mu 
-        
-    # project bottom-up error through weights
-    error_proj= bu_err @ layer.weight      
+        dE_dmu = bu_err
+        error_proj= dE_dmu @ layer.weight
+            
     error = error_proj- td_err if td_err is not None else error_proj  
-    
+   
     if lateral_conn is not None:
         delta_x = lateral_conn.forward(x, error)
         x = x + local_lr * delta_x
@@ -119,11 +125,11 @@ def step_linear(
     
     # parameter updates for the layer
     if requires_update:
-        delta_W = local_lr * torch.einsum("bsv, bsh -> vh", bu_err, x_input.detach())
+        delta_W = local_lr * torch.einsum("bsv, bsh -> vh", dE_dmu, x_input.detach())
         delta_W = torch.clamp(delta_W, -0.01, 0.01)
         layer.weight.data.add_(delta_W)
         if layer.bias is not None and update_bias:
-            delta_b = local_lr * bu_err.mean(dim=(0, 1))
+            delta_b = local_lr * dE_dmu.mean(dim=(0, 1))
             delta_b = torch.clamp(delta_b, -0.01, 0.01)
             layer.bias.data.add_(delta_b)
 

--- a/utils/pc_utils.py
+++ b/utils/pc_utils.py
@@ -269,23 +269,38 @@ def step_attn(
     dE_dK = torch.matmul(dE_dS.transpose(-2, -1), Q) * scale
 
     # Gradients through RoPE (using transpose)
-    cos_s = cos[:S].unsqueeze(0).unsqueeze(0)
-    sin_s = sin[:S].unsqueeze(0).unsqueeze(0)
+    cos_q = cos[:S].unsqueeze(0).unsqueeze(0)
+    sin_q = sin[:S].unsqueeze(0).unsqueeze(0)
     
-    dE_dQ_raw = (dE_dQ * cos_s) + (rotate_half_transpose(dE_dQ) * sin_s)
-    dE_dK_raw = (dE_dK * cos_s) + (rotate_half_transpose(dE_dK) * sin_s)
+    K_len = K.size(2)
+    cos_k = cos[:K_len].unsqueeze(0).unsqueeze(0)
+    sin_k = sin[:K_len].unsqueeze(0).unsqueeze(0)
+    
+    dE_dQ_raw = (dE_dQ * cos_q) + (rotate_half_transpose(dE_dQ) * sin_q)
+    dE_dK_raw = (dE_dK * cos_k) + (rotate_half_transpose(dE_dK) * sin_k)
     
     delta_x = torch.zeros_like(x_norm)
 
     # Update x per head
     for h in range(num_heads):
-        delta_x_h = (
-            dE_dQ_raw[:, h] @ q_proj.weight[:, h*head_dim:(h+1)*head_dim].T +
-            dE_dK_raw[:, h] @ k_proj.weight[:, h*head_dim:(h+1)*head_dim].T +
-            dE_dV[:, h] @ v_proj.weight[:, h*head_dim:(h+1)*head_dim].T
-        )
-        delta_x += delta_x_h
+        dq = dE_dQ_raw[:, h]        # [B, S, head_dim]
+        dk = dE_dK_raw[:, h]        # [B, K_len, head_dim]
+        dv = dE_dV[:, h]            # [B, K_len, head_dim]
         
+        if dk.size(1) > S:
+            dk = dk[:, -S:, :]
+            dv = dv[:, -S:, :]
+        
+        wq = q_proj.weight[:, h*head_dim:(h+1)*head_dim]
+        wk = k_proj.weight[:, h*head_dim:(h+1)*head_dim]
+        wv = v_proj.weight[:, h*head_dim:(h+1)*head_dim]
+        
+        delta_q = torch.einsum('bsh,eh->bse', dq, wq)
+        delta_k = torch.einsum('bsh,eh->bse', dk, wk)
+        delta_v = torch.einsum('bsh,eh->bse', dv, wv)
+        
+        delta_x += delta_q + delta_k + delta_v
+            
     if lateral_conn is not None:
         delta_x = lateral_conn.forward(x, delta_x)
         x = x + local_lr * delta_x
@@ -311,7 +326,21 @@ def step_attn(
                 q_proj.weight.data[:, h*head_dim:(h+1)*head_dim] += local_lr * dW_q
                 k_proj.weight.data[:, h*head_dim:(h+1)*head_dim] += local_lr * dW_k
                 v_proj.weight.data[:, h*head_dim:(h+1)*head_dim] += local_lr * dW_v
-
+                if update_bias:
+                    if q_proj.bias is not None:
+                        db_q = dE_dQ_raw[:, h].mean(dim=(0, 1))
+                        db_q = torch.clamp(db_q, -0.01, 0.01)
+                        q_proj.bias.data[h*head_dim:(h+1)*head_dim] += local_lr * db_q
+                    
+                    if k_proj.bias is not None:
+                        db_k = dE_dK_raw[:, h].mean(dim=(0, 1))
+                        db_k = torch.clamp(db_k, -0.01, 0.01)
+                        k_proj.bias.data[h*head_dim:(h+1)*head_dim] += local_lr * db_k
+                    
+                    if v_proj.bias is not None:
+                        db_v = dE_dV[:, h].mean(dim=(0, 1))
+                        db_v = torch.clamp(db_v, -0.01, 0.01)
+                        v_proj.bias.data[h*head_dim:(h+1)*head_dim] += local_lr * db_v
     new_kv_cache = (K.detach(), V.detach()) if use_cache else None
     return x, mu, bu_err, new_kv_cache
 

--- a/utils/pc_utils.py
+++ b/utils/pc_utils.py
@@ -49,6 +49,16 @@ def apply_rotary_emb(xq: torch.Tensor, xk: torch.Tensor, cos: torch.Tensor, sin:
     xk_out = (xk * cos) + (rotate_half(xk) * sin)
     return xq_out, xk_out
 
+def rotate_half_transpose(x: torch.Tensor) -> torch.Tensor:
+    """
+    Transpose of rotate_half operation.
+    Forward: [x1, x2] -> [-x2, x1]
+    Transpose: [y1, y2] -> [y2, -y1]
+    """
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((x2, -x1), dim=-1)
+
 def step_embed(
     t: int,
     T: int,
@@ -85,7 +95,7 @@ def step_embed(
             delta = torch.clamp(local_lr * flat_update, -0.01, 0.01)
             word_layer.weight.data.index_add_(0, flat_input_ids, delta)
             
-    return mu, mu_word, mu_pos, error
+    return mu, mu_word, error
     
 def step_linear(
     t: int,
@@ -124,7 +134,7 @@ def step_linear(
     if layer_type=="linear_output":
         probs = F.softmax(mu, dim=-1) 
         bu_err= target - probs
-        dE_dp= -bu_err
+        dE_dp= bu_err
         norm_term = (dE_dp * probs).sum(dim=-1, keepdim=True)
         dE_dmu = probs * (dE_dp - norm_term)
         error_proj= dE_dmu @ layer.weight     # project bottom-up error through weights
@@ -151,7 +161,7 @@ def step_linear(
         delta_W = torch.clamp(delta_W, -0.01, 0.01)
         layer.weight.data.add_(delta_W)
         if layer.bias is not None and update_bias:
-            delta_b = local_lr * bu_err.mean(dim=(0, 1))
+            delta_b = local_lr * dE_dmu.mean(dim=(0, 1))
             layer.bias.data.add_(torch.clamp(delta_b, -0.01, 0.01))
 
     return x, mu, bu_err
@@ -229,16 +239,18 @@ def step_attn(
     else:
         mu_heads, attn_weights, attn_scores = apply_standard_attention(Q, K, V, mask=causal_mask)
     
-    mu = mu_heads.transpose(1, 2).contiguous().view(batch_size, seq_len, embed_dim)
-    bu_err = target - mu  # B, T, D
+    mu = mu_heads.transpose(1, 2).contiguous().view(B, S, E)
+    bu_err = target - mu
     
     error = bu_err - td_err if td_err is not None else bu_err  
      
     scale = 1.0 / (head_dim ** 0.5)
 
-    dE_dmu = -bu_err  
-    dE_dmu_heads = dE_dmu.view(batch_size, num_heads, seq_len, head_dim)
-    # dE/dV = A^T @ dE/dμ
+    # Backward pass (manual gradients)
+    dE_dmu = bu_err  
+    dE_dmu_heads = dE_dmu.view(B, num_heads, S, head_dim)
+    
+    # dE/dV
     dE_dV = torch.matmul(attn_weights.transpose(-2, -1), dE_dmu_heads)
 
     # dE/dA = dE/dμ @ V^T
@@ -247,18 +259,30 @@ def step_attn(
     # Softmax vector-Jacobian product
     norm_term = (dE_dA * attn_weights).sum(dim=-1, keepdim=True)
     dE_dS = attn_weights * (dE_dA - norm_term)
+    
+    # Apply causal mask to gradients
+    if causal_mask is not None:
+        dE_dS = dE_dS.masked_fill(causal_mask == 0, 0.0)
 
+    # Gradients through Q and K
     dE_dQ = torch.matmul(dE_dS, K) * scale
     dE_dK = torch.matmul(dE_dS.transpose(-2, -1), Q) * scale
 
+    # Gradients through RoPE (using transpose)
+    cos_s = cos[:S].unsqueeze(0).unsqueeze(0)
+    sin_s = sin[:S].unsqueeze(0).unsqueeze(0)
+    
+    dE_dQ_raw = (dE_dQ * cos_s) + (rotate_half_transpose(dE_dQ) * sin_s)
+    dE_dK_raw = (dE_dK * cos_s) + (rotate_half_transpose(dE_dK) * sin_s)
+    
     delta_x = torch.zeros_like(x_norm)
 
     # Update x per head
     for h in range(num_heads):
         delta_x_h = (
-            dE_dQ[:, h] @ q_proj.weight[h*head_dim:(h+1)*head_dim] +
-            dE_dK[:, h] @ k_proj.weight[h*head_dim:(h+1)*head_dim] +
-            dE_dV[:, h] @ v_proj.weight[h*head_dim:(h+1)*head_dim]
+            dE_dQ_raw[:, h] @ q_proj.weight[:, h*head_dim:(h+1)*head_dim].T +
+            dE_dK_raw[:, h] @ k_proj.weight[:, h*head_dim:(h+1)*head_dim].T +
+            dE_dV[:, h] @ v_proj.weight[:, h*head_dim:(h+1)*head_dim].T
         )
         delta_x += delta_x_h
         
@@ -274,16 +298,21 @@ def step_attn(
     x = torch.clamp(x, -abs(clamp_value), abs(clamp_value))
 
     if requires_update:
-      with torch.no_grad():
-        for h in range(num_heads):
-            dW_q = torch.einsum("btd,bte->de", dE_dQ[:, h], x_norm)
-            dW_k = torch.einsum("btd,bte->de", dE_dK[:, h], x_norm)
-            dW_v = torch.einsum("btd,bte->de", dE_dV[:, h], x_norm)
-            q_proj.weight.data[h*head_dim:(h+1)*head_dim] += local_lr * dW_q
-            k_proj.weight.data[h*head_dim:(h+1)*head_dim] += local_lr * dW_k
-            v_proj.weight.data[h*head_dim:(h+1)*head_dim] += local_lr * dW_v
+        with torch.no_grad():
+            for h in range(num_heads):
+                dW_q = torch.einsum("bte,btd->ed", x_norm, dE_dQ_raw[:, h])
+                dW_k = torch.einsum("bte,btd->ed", x_norm, dE_dK_raw[:, h])
+                dW_v = torch.einsum("bte,btd->ed", x_norm, dE_dV[:, h])
+                
+                dW_q = torch.clamp(dW_q, -0.01, 0.01)
+                dW_k = torch.clamp(dW_k, -0.01, 0.01)
+                dW_v = torch.clamp(dW_v, -0.01, 0.01)
+                
+                q_proj.weight.data[:, h*head_dim:(h+1)*head_dim] += local_lr * dW_q
+                k_proj.weight.data[:, h*head_dim:(h+1)*head_dim] += local_lr * dW_k
+                v_proj.weight.data[:, h*head_dim:(h+1)*head_dim] += local_lr * dW_v
 
-         
+    new_kv_cache = (K.detach(), V.detach()) if use_cache else None
     return x, mu, bu_err, new_kv_cache
 
 ENERGY_FUNCTIONS = {

--- a/utils/pc_utils.py
+++ b/utils/pc_utils.py
@@ -98,11 +98,11 @@ def step_linear(
         mu = layer_norm(mu)
             
     if layer_type=="linear_output":
-        p = F.softmax(mu, dim=-1) 
+        probs = F.softmax(mu, dim=-1) 
         bu_err= target - p
         dE_dp= -bu_err
-        inner = (dE_dp * p).sum(dim=-1, keepdim=True)
-        dE_dmu = p * (dE_dp - inner)
+        norm_term = (dE_dp * p).sum(dim=-1, keepdim=True)
+        dE_dmu = p * (dE_dp - norm_term)
         error_proj= dE_dmu @ layer.weight     # project bottom-up error through weights
 
     else:    
@@ -224,8 +224,8 @@ def step_attn(
     dE_dA = torch.matmul(dE_dmu_heads, V.transpose(-2, -1))
 
     # Softmax vector-Jacobian product
-    inner = (dE_dA * attn_weights).sum(dim=-1, keepdim=True)
-    dE_dS = attn_weights * (dE_dA - inner)
+    norm_term = (dE_dA * attn_weights).sum(dim=-1, keepdim=True)
+    dE_dS = attn_weights * (dE_dA - norm_term)
 
     dE_dQ = torch.matmul(dE_dS, K) * scale
     dE_dK = torch.matmul(dE_dS.transpose(-2, -1), Q) * scale

--- a/utils/pc_utils.py
+++ b/utils/pc_utils.py
@@ -200,60 +200,63 @@ def step_attn(
     if flash:
         mu_heads = apply_flash_attention(Q, K, V, mask=causal_mask)
     else:
-        mu_heads = apply_standard_attention(Q, K, V, mask=causal_mask)
+        mu_heads, attn_weights, attn_scores = apply_standard_attention(Q, K, V, mask=causal_mask)
     
     mu = mu_heads.transpose(1, 2).contiguous().view(batch_size, seq_len, embed_dim)
-    
     bu_err = target - mu  # B, T, D
+    
     error = bu_err - td_err if td_err is not None else bu_err  
-                
+     
+    scale = 1.0 / (head_dim ** 0.5)
+
+    dE_dmu = -bu_err  
+    dE_dmu_heads = dE_dmu.view(batch_size, num_heads, seq_len, head_dim)
+    # dE/dV = A^T @ dE/dμ
+    dE_dV = torch.matmul(attn_weights.transpose(-2, -1), dE_dmu_heads)
+
+    # dE/dA = dE/dμ @ V^T
+    dE_dA = torch.matmul(dE_dmu_heads, V.transpose(-2, -1))
+
+    # Softmax vector-Jacobian product
+    inner = (dE_dA * attn_weights).sum(dim=-1, keepdim=True)
+    dE_dS = attn_weights * (dE_dA - inner)
+
+    dE_dQ = torch.matmul(dE_dS, K) * scale
+    dE_dK = torch.matmul(dE_dS.transpose(-2, -1), Q) * scale
+
+    delta_x = torch.zeros_like(x_norm)
+
+    # Update x per head
+    for h in range(num_heads):
+        delta_x_h = (
+            dE_dQ[:, h] @ q_proj.weight[h*head_dim:(h+1)*head_dim] +
+            dE_dK[:, h] @ k_proj.weight[h*head_dim:(h+1)*head_dim] +
+            dE_dV[:, h] @ v_proj.weight[h*head_dim:(h+1)*head_dim]
+        )
+        delta_x += delta_x_h
+        
     if lateral_conn is not None:
-        delta_x = lateral_conn.forward(x, error)
+        delta_x = lateral_conn.forward(x, delta_x)
         x = x + local_lr * delta_x
         
         if requires_update:
             lateral_conn.update_weights(x.detach())
     else:
-        x = x + local_lr * error
+        x = x + local_lr * delta_x
 
     x = torch.clamp(x, -abs(clamp_value), abs(clamp_value))
 
-    # PC update W_latent
     if requires_update:
-        with torch.no_grad():
-            B, S = batch_size, seq_len
+      with torch.no_grad():
+        for h in range(num_heads):
+            dW_q = torch.einsum("btd,bte->de", dE_dQ[:, h], x_norm)
+            dW_k = torch.einsum("btd,bte->de", dE_dK[:, h], x_norm)
+            dW_v = torch.einsum("btd,bte->de", dE_dV[:, h], x_norm)
+            q_proj.weight.data[h*head_dim:(h+1)*head_dim] += local_lr * dW_q
+            k_proj.weight.data[h*head_dim:(h+1)*head_dim] += local_lr * dW_k
+            v_proj.weight.data[h*head_dim:(h+1)*head_dim] += local_lr * dW_v
 
-            K_update = K[:, :, -seq_len:, :] 
-            V_update = V[:, :, -seq_len:, :]
-            
-            # Multi-head Q, K, V updates
-            for h in range(num_heads):
-                q_slice = Q[:, h, :, :]  # [B, S, head_dim]
-                k_slice = K_update[:, h, :, :]
-                v_slice = V_update[:, h, :, :]
-                
-                dW_q_h = torch.einsum("bsd,bse->de", q_slice, x_norm) / (B * S)
-                dW_k_h = torch.einsum("bsd,bse->de", k_slice, x_norm) / (B * S)
-                dW_v_h = torch.einsum("bsd,bse->de", v_slice, x_norm) / (B * S)
-
-                start = h * head_dim
-                end = (h + 1) * head_dim
-                
-                q_proj.weight.data[start:end, :] += torch.clamp(local_lr * dW_q_h, -clamp_value, clamp_value)
-                k_proj.weight.data[start:end, :] += torch.clamp(local_lr * dW_k_h, -clamp_value, clamp_value)
-                v_proj.weight.data[start:end, :] += torch.clamp(local_lr * dW_v_h, -clamp_value, clamp_value)
-                
-                if update_bias:
-                    if q_proj.bias is not None:
-                        delta_b_q = (q_slice.mean(dim=(0, 1)) / (B * S))
-                        q_proj.bias.data[start:end] += torch.clamp(local_lr * delta_b_q, -clamp_value, clamp_value)
-                    if k_proj.bias is not None:
-                        delta_b_k = (k_slice.mean(dim=(0, 1)) / (B * S))
-                        k_proj.bias.data[start:end] += torch.clamp(local_lr * delta_b_k, -clamp_value, clamp_value)
-                    if v_proj.bias is not None:
-                        delta_b_v = (v_slice.mean(dim=(0, 1)) / (B * S))
-                        v_proj.bias.data[start:end] += torch.clamp(local_lr * delta_b_v, -clamp_value, clamp_value)
- 
+         
     if t == T - 1:
         finalize_step(mu, target, error, t, layer_type,energy_fn_name)
      

--- a/utils/pc_utils.py
+++ b/utils/pc_utils.py
@@ -58,9 +58,6 @@ def step_embed(
             word_layer.weight.data.index_add_(0, flat_input_ids, delta)
             pos_layer.weight.data.index_add_(0, flat_position_ids, delta)
             
-    if t == T - 1:
-           finalize_step(mu, target, error, t, layer_type, energy_fn_name)
-  
     return mu, mu_word, mu_pos, error
     
 def step_linear(
@@ -99,10 +96,10 @@ def step_linear(
             
     if layer_type=="linear_output":
         probs = F.softmax(mu, dim=-1) 
-        bu_err= target - p
+        bu_err= target - probs
         dE_dp= -bu_err
-        norm_term = (dE_dp * p).sum(dim=-1, keepdim=True)
-        dE_dmu = p * (dE_dp - norm_term)
+        norm_term = (dE_dp * probs).sum(dim=-1, keepdim=True)
+        dE_dmu = probs * (dE_dp - norm_term)
         error_proj= dE_dmu @ layer.weight     # project bottom-up error through weights
 
     else:    
@@ -132,9 +129,6 @@ def step_linear(
             delta_b = local_lr * dE_dmu.mean(dim=(0, 1))
             delta_b = torch.clamp(delta_b, -0.01, 0.01)
             layer.bias.data.add_(delta_b)
-
-    if t == T - 1:
-        finalize_step(mu, target, error, t, layer_type,energy_fn_name)
 
     return x, mu, bu_err
 
@@ -263,9 +257,6 @@ def step_attn(
             v_proj.weight.data[h*head_dim:(h+1)*head_dim] += local_lr * dW_v
 
          
-    if t == T - 1:
-        finalize_step(mu, target, error, t, layer_type,energy_fn_name)
-     
     return x, mu, bu_err, new_kv_cache
     
 ENERGY_FUNCTIONS = {


### PR DESCRIPTION
This PR replaces single error-based updates with gradient-based updates across attention and output layers, enabling proper credit assignment by propagating error derivatives through each component instead of relying on a shared error signal.

**Changes**

**Gradient computation for output layer**

→ Since the current error includes probabilities as predictions, the derivative now incorporates the softmax Jacobian for accurate weight and latent state updates. [762f450](https://github.com/iCog-Labs-Dev/PC-Transformers/commit/762f4503963e229c1bddbce07df7a157658df5ab)


**Expanded attention gradient updates**

→ Replaced single-error updates with component-wise gradients across attention scores, weights, Q, K, V projections. [1517407](https://github.com/iCog-Labs-Dev/PC-Transformers/commit/1517407330be04f3ae314f35b5bc2e2167c6cc6f)


**Integrated rotary position encoding (RoPE) into gradient computation**

→ Includes rotated K and V to ensure gradients reflect the true contribution of positional rotations. [35b5f47
](https://github.com/iCog-Labs-Dev/PC-Transformers/commit/35b5f47a1b546e7c601654d1d885f155e115bbd1)


Current Training Result
Parameters: 1.29M
| Epoch | Train Energy | Train Perplexity | Val Energy | Val Perplexity |
| ---- | ------------| ---------------| ----------  | ------------- | 
| 1     | 1.4001       | 1218.50          | 1.3749     | 1216.91        |
| 2     | 1.3701       | 1218.53          | 1.3630     | 1216.38        |
| 3     | 1.3647       | 1220.93          | 1.3620     | 1224.40        |
| 4     | 1.3643       | 1222.16          | 1.3627     | 1234.06        |
| 5     | 1.3637       | 1221.54          | 1.3625     | 1224.39        |
