### PR TITLE
Implement inference learning rate for the latents

### DIFF
--- a/benchmark_T.py
+++ b/benchmark_T.py
@@ -35,6 +35,7 @@ def benchmark_T(T_values=[2, 3, 4, 5, 6, 8, 10], num_epochs=5):
             vocab_size = vocab_size,
             block_size = best_config["block_size"],
             lr = best_config["lr"],
+            inference_lr = best_config["inference_lr"],
             peak_learning_rate = best_config["peak_learning_rate"],
             warmup_steps = best_config["warmup_steps"],
             n_embed = best_config["n_embed"],

--- a/benchmark_blocks.py
+++ b/benchmark_blocks.py
@@ -35,6 +35,7 @@ def benchmark_blocks(block_values=[2, 3, 4, 5, 6], num_epochs=5):
             vocab_size = vocab_size,
             block_size = best_config["block_size"],
             lr = best_config["lr"],
+            inference_lr = best_config["inference_lr"],
             peak_learning_rate = best_config["peak_learning_rate"],
             warmup_steps = best_config["warmup_steps"],
             n_embed = best_config["n_embed"],

--- a/eval.py
+++ b/eval.py
@@ -115,6 +115,7 @@ def main():
         vocab_size = vocab_size,
         block_size = best_config["block_size"],
         lr = best_config["peak_learning_rate"],
+        inference_lr = best_config["inference_lr"],
         peak_learning_rate = best_config["peak_learning_rate"],
         warmup_steps = best_config["warmup_steps"],
         n_embed = best_config["n_embed"],

--- a/generate_text.py
+++ b/generate_text.py
@@ -90,6 +90,7 @@ def main():
         vocab_size = vocab_size,
         block_size = best_config["block_size"],
         lr = best_config["peak_learning_rate"],
+        inference_lr = best_config["inference_lr"],
         peak_learning_rate = best_config["peak_learning_rate"],
         warmup_steps = best_config["warmup_steps"],
         n_embed = best_config["n_embed"],

--- a/model_architecture/attention.py
+++ b/model_architecture/attention.py
@@ -23,6 +23,7 @@ class Attention(nn.Module):
         self.pc_qkv = PCLayer(
             T=config.T,
             lr=config.lr,
+            inference_lr=config.inference_lr,
             update_bias = config.update_bias,
             energy_fn_name=config.internal_energy_fn_name,
             num_heads=config.num_heads,
@@ -32,6 +33,7 @@ class Attention(nn.Module):
         self.pc_output = PCLayer(
             T=config.T,
             lr=config.lr,
+            inference_lr=config.inference_lr,
             update_bias = config.update_bias,
             energy_fn_name=config.internal_energy_fn_name,
         )

--- a/model_architecture/embedding.py
+++ b/model_architecture/embedding.py
@@ -15,6 +15,7 @@ class Embedding_Layer(nn.Module):
         self.pc_layer= PCLayer(
             T=config.T,
             lr=config.lr,
+            inference_lr=config.inference_lr,
             update_bias = config.update_bias,
             energy_fn_name=config.internal_energy_fn_name,                    
         )

--- a/model_architecture/mlp.py
+++ b/model_architecture/mlp.py
@@ -16,6 +16,7 @@ class MLP(nn.Module):
         self.pc_layer2 = PCLayer(
             T=config.T,
             lr=config.lr,
+            inference_lr=config.inference_lr,
             update_bias=config.update_bias,
             energy_fn_name=config.internal_energy_fn_name,
         )
@@ -23,6 +24,7 @@ class MLP(nn.Module):
         self.pc_layer1 = PCLayer(
             T=config.T,
             lr=config.lr,
+            inference_lr=config.inference_lr,
             update_bias=config.update_bias,
             energy_fn_name=config.internal_energy_fn_name,
         )

--- a/model_architecture/output.py
+++ b/model_architecture/output.py
@@ -13,6 +13,7 @@ class OutputLayer(nn.Module):
         self.pc_layer = PCLayer(
             T=config.T,
             lr=config.lr,
+            inference_lr=config.inference_lr,
             update_bias = config.update_bias,
             energy_fn_name=config.output_energy_fn_name,
         )

--- a/predictive_coding/config.py
+++ b/predictive_coding/config.py
@@ -26,6 +26,7 @@ class GPTConfig:
     vocab_size: int
     block_size: int
     lr: float
+    inference_lr: float
     peak_learning_rate: Optional[float]
     warmup_steps: Optional[int] 
     n_embed: int 

--- a/predictive_coding/lateral_connc.py
+++ b/predictive_coding/lateral_connc.py
@@ -7,10 +7,11 @@ class LateralConnections(nn.Module):
     Manages lateral connections for a layer.
     Implements anti-Hebbian learning for decorrelation.
     """
-    def __init__(self, size: int, local_lr: float):
+    def __init__(self, size: int, local_lr: float, inference_lr: float):
         super().__init__()
         self.size = size
         self.local_lr = local_lr
+        self.inference_lr = inference_lr
         
         # Initialize lateral weight matrix
         W = torch.empty(size, size)
@@ -43,3 +44,7 @@ class LateralConnections(nn.Module):
     def set_learning_rate(self, lr: float):
         """Set the local learning rate for the layer."""
         self.local_lr = float(lr)
+    
+    def set_inference_learning_rate(self, inference_lr: float):
+        """Set the inference learning rate for the layer."""
+        self.inference_lr = float(inference_lr)

--- a/predictive_coding/pc_layer.py
+++ b/predictive_coding/pc_layer.py
@@ -20,6 +20,7 @@ class PCLayer(nn.Module):
         self,
         T: int,
         lr: float,
+        inference_lr: float,
         update_bias: bool,
         energy_fn_name: str,
         num_heads: Optional[int] = None,
@@ -29,6 +30,7 @@ class PCLayer(nn.Module):
         self.rope_cache: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
         self.T = T
         self.local_lr = lr
+        self.inference_lr = inference_lr
         self.update_bias = update_bias
         self.clamp_value = 3.0
         self.energy_fn_name = energy_fn_name 
@@ -46,7 +48,7 @@ class PCLayer(nn.Module):
     def register_lateral(self, layer_type: str, size: int):
         """Create and register lateral connections for layer_type."""
         if layer_type not in self.lateral_connections:
-            self.lateral_connections[layer_type] = LateralConnections(size, self.local_lr)
+            self.lateral_connections[layer_type] = LateralConnections(size, self.local_lr, self.inference_lr)
             self.add_module(f"lateral_{layer_type}", self.lateral_connections[layer_type])
 
     def _reset_step_state(self) -> None:
@@ -120,6 +122,7 @@ class PCLayer(nn.Module):
                 proj_layers,
                 layer_type,
                 self.local_lr,
+                self.inference_lr,
                 self.clamp_value,
                 self.energy_fn_name,
                 self.update_bias,
@@ -148,6 +151,7 @@ class PCLayer(nn.Module):
                 lateral_conn,  
                 layer_type,
                 self.local_lr, 
+                self.inference_lr,
                 self.clamp_value, 
                 self.energy_fn_name, 
                 self.update_bias, 
@@ -253,7 +257,14 @@ class PCLayer(nn.Module):
     def set_learning_rate(self, lr: float):
         """Set the local learning rate for the layer."""
         self.local_lr = float(lr)
+    def set_inference_learning_rate(self, inference_lr: float):
+        """Set the inference learning rate for the layer."""
+        self.inference_lr = float(inference_lr)
         
     def get_learning_rate(self) -> float:
         """Get the current local learning rate for the layer."""
         return float(self.local_lr)
+    
+    def get_inference_learning_rate(self) -> float:
+        """Get the current inference learning rate for the layer."""
+        return float(self.inference_lr)

--- a/training.py
+++ b/training.py
@@ -158,6 +158,7 @@ def main():
         vocab_size = vocab_size,
         block_size = best_config["block_size"],
         lr = best_config["lr"],
+        inference_lr = best_config["inference_lr"],
         peak_learning_rate = best_config["peak_learning_rate"],
         warmup_steps = best_config["warmup_steps"],
         n_embed = best_config["n_embed"],

--- a/tuning/config.py
+++ b/tuning/config.py
@@ -18,7 +18,8 @@ def get_dynamic_model_config(trial, vocab_size, flash=False):
     T = trial.suggest_int('T', 1, 14, log=True)
     dropout = trial.suggest_float("dropout", 0.0, 0.5)
     peak_lr = trial.suggest_float('peak_lr', 1e-5, 1e-2, log=True)
-    lr = peak_lr * 0.1 
+    lr = peak_lr * 0.1
+    inference_lr = lr * 100 
     warmup_steps = trial.suggest_int('warmup_steps', 50, 2000, log=True)
     update_bias = trial.suggest_int('update_bias_int', 0, 1) == 1
     batch_size = trial.suggest_categorical('batch_size', [4, 8, 16, 32])
@@ -35,6 +36,7 @@ def get_dynamic_model_config(trial, vocab_size, flash=False):
         n_embed=n_embed,
         dropout=dropout,
         lr=lr, 
+        inference_lr=inference_lr,
         T=T,
         num_heads=num_heads,
         n_blocks=n_blocks,

--- a/utils/config_utils.py
+++ b/utils/config_utils.py
@@ -10,7 +10,7 @@ def load_best_config():
     selected_keys = {
         "block_size", "peak_learning_rate", "warmup_steps", "n_embed",
         "dropout", "T", "num_heads", "n_blocks", "update_bias", "alpha",
-        "lr", "batch_size", "num_epochs", "internal_energy_fn_name",
+        "lr", "inference_lr", "batch_size", "num_epochs", "internal_energy_fn_name",
         "output_energy_fn_name", "combined_internal_weight",
         "combined_output_weight", "use_flash_attention"
     }
@@ -27,6 +27,7 @@ def load_best_config():
         "update_bias": False,
         "alpha": 0.5,
         "lr": 0.0009606017304857476,
+        "inference_lr": 0.096,
         "batch_size": 8,
         "num_epochs": 10,
         "internal_energy_fn_name": "pc_e",

--- a/utils/pc_utils.py
+++ b/utils/pc_utils.py
@@ -106,6 +106,7 @@ def step_linear(
     lateral_conn: Optional[Any], 
     layer_type: str,
     local_lr: float,
+    inference_lr: float,
     clamp_value: float,
     energy_fn_name: str,
     update_bias: bool,
@@ -147,11 +148,11 @@ def step_linear(
     error = error_proj- td_err if td_err is not None else error_proj  
    
     if lateral_conn is not None:
-        x = x + local_lr * lateral_conn.forward(x, error)
+        x = x + inference_lr * lateral_conn.forward(x, error)
         if requires_update:
             lateral_conn.update_weights(x.detach())
     else:
-        x = x + local_lr * error 
+        x = x + inference_lr * error 
 
     x = torch.clamp(x, -abs(clamp_value), abs(clamp_value))
     
@@ -175,6 +176,7 @@ def step_attn(
     proj_layers: dict,
     layer_type: str,
     local_lr: float,
+    inference_lr: float,
     clamp_value: float,
     energy_fn_name: str,
     update_bias: bool,
@@ -303,12 +305,12 @@ def step_attn(
             
     if lateral_conn is not None:
         delta_x = lateral_conn.forward(x, delta_x)
-        x = x + local_lr * delta_x
+        x = x + inference_lr * delta_x
         
         if requires_update:
             lateral_conn.update_weights(x.detach())
     else:
-        x = x + local_lr * delta_x
+        x = x + inference_lr * delta_x
 
     x = torch.clamp(x, -abs(clamp_value), abs(clamp_value))
 


### PR DESCRIPTION
This PR introduces separate hyper-parameters for state inference (activity updates) and parameter learning (weight/bias updates). By decoupling these learning rates, PR align the model with the distinct timescales required for fast inference and slow synaptic plasticity.
**Problem of Previous Implementation**
Previously, the model uses a single scalar learning rate (local_lr) for both state inference (updating unit activities x) and parameter learning (updating weights W and biases B). Using the same learning rate for updating x (inference) and W and B conflates two processes that must operate on different timescales. 

- **Inference** (Updating x): This needs to happen fast. The goal of the inner loop (T steps) is to quickly converge x to a state that minimizes energy before we update the weights.
- **Learning** (Updating W): This needs to happen slowly. Weights capture long-term statistical regularities. If weights change as fast as neural activities, the model becomes unstable because the "rulebook" (weights) changes while the model is still trying to read the current page (inference).

**Implemented Solution**
This PR decoupled the single learning rate into two distinct hyper-parameters:
- **inference_lr**: Applied solely to the iterative updates of state activities (x).
- **lr**: Applied solely to the updates of synaptic weights and biases (W, B).

This allows to tune the inner loop (inference) for rapid convergence without risking the stability of the outer loop (weight updates).