### PR TITLE
Add pluggable PCOptimizer supporting Adam, AdamW, SGD, and SGD-momentum for local PC weight and bias updates

### DIFF
--- a/benchmark_T.py
+++ b/benchmark_T.py
@@ -50,7 +50,12 @@ def benchmark_T(T_values=[2, 3, 4, 5, 6, 8, 10], num_epochs=5):
             combined_internal_weight = best_config["combined_internal_weight"],
             combined_output_weight = best_config["combined_output_weight"],
             use_flash_attention = best_config["use_flash_attention"],
-            alpha = best_config["alpha"]
+            alpha = best_config["alpha"],
+            optimizer_name = best_config["optimizer_name"],
+            optimizer_beta1 = best_config["optimizer_beta1"],
+            optimizer_beta2 = best_config["optimizer_beta2"],
+            optimizer_eps = best_config["optimizer_eps"],
+                        
         )
         
         # Initialize model

--- a/benchmark_blocks.py
+++ b/benchmark_blocks.py
@@ -50,7 +50,11 @@ def benchmark_blocks(block_values=[2, 3, 4, 5, 6], num_epochs=5):
             combined_internal_weight = best_config["combined_internal_weight"],
             combined_output_weight = best_config["combined_output_weight"],
             use_flash_attention = best_config["use_flash_attention"],
-            alpha = best_config["alpha"]
+            alpha = best_config["alpha"],
+            optimizer_name = best_config["optimizer_name"],
+            optimizer_beta1 = best_config["optimizer_beta1"],
+            optimizer_beta2 = best_config["optimizer_beta2"],
+            optimizer_eps = best_config["optimizer_eps"],
         )
         
         # Initialize model

--- a/eval.py
+++ b/eval.py
@@ -125,7 +125,11 @@ def main():
         combined_internal_weight=best_config["combined_internal_weight"],
         combined_output_weight=best_config["combined_output_weight"],
         use_flash_attention=best_config["use_flash_attention"],
-        alpha = best_config["alpha"]
+        alpha = best_config["alpha"],
+        optimizer_name = best_config["optimizer_name"],
+        optimizer_beta1 = best_config["optimizer_beta1"],
+        optimizer_beta2 = best_config["optimizer_beta2"],
+        optimizer_eps = best_config["optimizer_eps"],
     )
   
     model_path = "checkpoints/final_model.pt"

--- a/generate_text.py
+++ b/generate_text.py
@@ -105,7 +105,11 @@ def main():
         combined_internal_weight=best_config["combined_internal_weight"],
         combined_output_weight=best_config["combined_output_weight"],
         use_flash_attention=best_config["use_flash_attention"],
-        alpha = best_config["alpha"]    
+        alpha = best_config["alpha"],
+        optimizer_name = best_config["optimizer_name"],
+        optimizer_beta1 = best_config["optimizer_beta1"],
+        optimizer_beta2 = best_config["optimizer_beta2"],
+        optimizer_eps = best_config["optimizer_eps"],
     )
     
     model_path = "checkpoints/final_model.pt"

--- a/model_architecture/attention.py
+++ b/model_architecture/attention.py
@@ -27,6 +27,12 @@ class Attention(nn.Module):
             energy_fn_name=config.internal_energy_fn_name,
             num_heads=config.num_heads,
             n_embed=config.n_embed,
+            optimizer_name=config.optimizer_name,
+            optimizer_beta1=config.optimizer_beta1,
+            optimizer_beta2=config.optimizer_beta2,
+            optimizer_eps=config.optimizer_eps,
+            optimizer_momentum=config.optimizer_momentum,
+            optimizer_weight_decay=config.optimizer_weight_decay,
         )
 
         self.pc_output = PCLayer(
@@ -34,6 +40,12 @@ class Attention(nn.Module):
             lr=config.lr,
             inference_lr=config.inference_lr,
             energy_fn_name=config.internal_energy_fn_name,
+            optimizer_name=config.optimizer_name,
+            optimizer_beta1=config.optimizer_beta1,
+            optimizer_beta2=config.optimizer_beta2,
+            optimizer_eps=config.optimizer_eps,
+            optimizer_momentum=config.optimizer_momentum,
+            optimizer_weight_decay=config.optimizer_weight_decay,
         )
         
         # KV cache for generation: stores (K, V) tensors

--- a/model_architecture/embedding.py
+++ b/model_architecture/embedding.py
@@ -16,5 +16,11 @@ class Embedding_Layer(nn.Module):
             T=config.T,
             lr=config.lr,
             inference_lr=config.inference_lr,
-            energy_fn_name=config.internal_energy_fn_name,                    
+            energy_fn_name=config.internal_energy_fn_name, 
+            optimizer_name=config.optimizer_name,
+            optimizer_beta1=config.optimizer_beta1,
+            optimizer_beta2=config.optimizer_beta2,
+            optimizer_eps=config.optimizer_eps,
+            optimizer_momentum=config.optimizer_momentum,
+            optimizer_weight_decay=config.optimizer_weight_decay,
         )

--- a/model_architecture/mlp.py
+++ b/model_architecture/mlp.py
@@ -18,6 +18,12 @@ class MLP(nn.Module):
             lr=config.lr,
             inference_lr=config.inference_lr,
             energy_fn_name=config.internal_energy_fn_name,
+            optimizer_name=config.optimizer_name,
+            optimizer_beta1=config.optimizer_beta1,
+            optimizer_beta2=config.optimizer_beta2,
+            optimizer_eps=config.optimizer_eps,
+            optimizer_momentum=config.optimizer_momentum,
+            optimizer_weight_decay=config.optimizer_weight_decay,
         )
 
         self.pc_layer1 = PCLayer(
@@ -25,4 +31,10 @@ class MLP(nn.Module):
             lr=config.lr,
             inference_lr=config.inference_lr,
             energy_fn_name=config.internal_energy_fn_name,
+            optimizer_name=config.optimizer_name,
+            optimizer_beta1=config.optimizer_beta1,
+            optimizer_beta2=config.optimizer_beta2,
+            optimizer_eps=config.optimizer_eps,
+            optimizer_momentum=config.optimizer_momentum,
+            optimizer_weight_decay=config.optimizer_weight_decay,
         )

--- a/model_architecture/output.py
+++ b/model_architecture/output.py
@@ -15,4 +15,10 @@ class OutputLayer(nn.Module):
             lr=config.lr,
             inference_lr=config.inference_lr,
             energy_fn_name=config.output_energy_fn_name,
+            optimizer_name=config.optimizer_name,
+            optimizer_beta1=config.optimizer_beta1,
+            optimizer_beta2=config.optimizer_beta2,
+            optimizer_eps=config.optimizer_eps,
+            optimizer_momentum=config.optimizer_momentum,
+            optimizer_weight_decay=config.optimizer_weight_decay,
         )

--- a/model_architecture/output.py
+++ b/model_architecture/output.py
@@ -15,7 +15,7 @@ class OutputLayer(nn.Module):
             lr=config.lr,
             inference_lr=config.inference_lr,
             energy_fn_name=config.output_energy_fn_name,
-            optimizer_name=config.optimizer_name,
+            optimizer_name=config.output_optimizer_name,
             optimizer_beta1=config.optimizer_beta1,
             optimizer_beta2=config.optimizer_beta2,
             optimizer_eps=config.optimizer_eps,

--- a/predictive_coding/config.py
+++ b/predictive_coding/config.py
@@ -49,6 +49,5 @@ class GPTConfig:
     optimizer_beta1: float = 0.9
     optimizer_beta2: float = 0.999
     optimizer_eps: float = 1e-8
-    optimizer_weight_bound: float = 0.0
     optimizer_momentum: float = 0.9
     optimizer_weight_decay: float = 0.01

--- a/predictive_coding/config.py
+++ b/predictive_coding/config.py
@@ -46,6 +46,7 @@ class GPTConfig:
     use_flash_attention: bool
     alpha: float
     optimizer_name: str = "adam"
+    output_optimizer_name: str = "adam"
     optimizer_beta1: float = 0.9
     optimizer_beta2: float = 0.999
     optimizer_eps: float = 1e-8

--- a/predictive_coding/config.py
+++ b/predictive_coding/config.py
@@ -21,6 +21,10 @@ class GPTConfig:
         num_epochs (int): Number of training epochs.
         energy_fn_name (str): Name of the energy function to use for error computation.
         use_flash_attention (bool): Whether to use FlashAttention.
+        optimizer_name (str): Optimizer to use for PC weight updates (adam or sgd).
+        optimizer_beta1 (float): Adam beta1 coefficient.
+        optimizer_beta2 (float): Adam beta2 coefficient.
+        optimizer_eps (float): Adam epsilon.
     """
     vocab_size: int
     block_size: int
@@ -41,3 +45,10 @@ class GPTConfig:
     combined_output_weight: float
     use_flash_attention: bool
     alpha: float
+    optimizer_name: str = "adam"
+    optimizer_beta1: float = 0.9
+    optimizer_beta2: float = 0.999
+    optimizer_eps: float = 1e-8
+    optimizer_weight_bound: float = 0.0
+    optimizer_momentum: float = 0.9
+    optimizer_weight_decay: float = 0.01

--- a/predictive_coding/lateral_connc.py
+++ b/predictive_coding/lateral_connc.py
@@ -34,11 +34,14 @@ class LateralConnections(nn.Module):
         
         return delta_x
     
-    def update_weights(self, x: torch.Tensor):
+    def update_weights(self, x: torch.Tensor, optimizer=None, clamp_value: float = None):
         """Anti-Hebbian weight update for decorrelation. """
         with torch.no_grad():
             anti_hebbian = -torch.einsum("bsh,bsv->hv", x, x)
-            self.W_lateral.data.add_(self.local_lr * anti_hebbian)
+            if optimizer is not None:
+                optimizer.step_param(self.W_lateral, anti_hebbian, self.local_lr, clamp_value=clamp_value)
+            else:
+                self.W_lateral.data.add_(self.local_lr * anti_hebbian)
             self.W_lateral.data = F.normalize(self.W_lateral.data, p=2, dim=1)
             
     def set_learning_rate(self, lr: float):

--- a/predictive_coding/pc_layer.py
+++ b/predictive_coding/pc_layer.py
@@ -9,6 +9,7 @@ from utils.pc_utils import (
     step_attn,
     finalize_step,
 )
+from utils.optim.optim_utils import PCOptimizer
 from predictive_coding.lateral_connc import LateralConnections
 
 class PCLayer(nn.Module):
@@ -24,6 +25,12 @@ class PCLayer(nn.Module):
         energy_fn_name: str,
         num_heads: Optional[int] = None,
         n_embed: Optional[int] = None,
+        optimizer_name: str = "adam",
+        optimizer_beta1: float = 0.9,
+        optimizer_beta2: float = 0.999,
+        optimizer_eps: float = 1e-8,
+        optimizer_momentum: float = 0.9,
+        optimizer_weight_decay: float = 0.01,
     ):
         super().__init__()
         self.rope_cache: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
@@ -31,9 +38,17 @@ class PCLayer(nn.Module):
         self.local_lr = lr
         self.inference_lr = inference_lr
         self.clamp_value = 3.0
-        self.energy_fn_name = energy_fn_name 
+        self.energy_fn_name = energy_fn_name
         self.num_heads = num_heads
         self.n_embed = n_embed
+        self.optimizer = PCOptimizer(
+            opt_name=optimizer_name,
+            beta1=optimizer_beta1,
+            beta2=optimizer_beta2,
+            eps=optimizer_eps,
+            momentum=optimizer_momentum,
+            weight_decay=optimizer_weight_decay,
+        )
         
         self.lateral_connections: Dict[str, LateralConnections] = {}
         
@@ -95,6 +110,7 @@ class PCLayer(nn.Module):
                 self.energy_fn_name,
                 requires_update,
                 layer_norm=layer_norm,
+                optimizer=self.optimizer,
             )            
             # store for later retrieval
             self._x_cache["embed"] = (mu_word)
@@ -132,6 +148,7 @@ class PCLayer(nn.Module):
                 flash=flash, 
                 kv_cache=kv_cache,  
                 use_cache=use_cache,
+                optimizer=self.optimizer,
             )
             # Store cache for retrieval
             if use_cache:
@@ -153,7 +170,8 @@ class PCLayer(nn.Module):
                 self.energy_fn_name, 
                 requires_update,
                 td_err=td_err, 
-                layer_norm=layer_norm
+                layer_norm=layer_norm,
+                optimizer=self.optimizer,
             )
             
         # cache and stats

--- a/training.py
+++ b/training.py
@@ -169,6 +169,7 @@ def main():
         use_flash_attention=best_config["use_flash_attention"],
         alpha = best_config["alpha"],
         optimizer_name = best_config["optimizer_name"],
+        output_optimizer_name = best_config.get("output_optimizer_name", "adam"),
         optimizer_beta1 = best_config["optimizer_beta1"],
         optimizer_beta2 = best_config["optimizer_beta2"],
         optimizer_eps = best_config["optimizer_eps"],

--- a/training.py
+++ b/training.py
@@ -146,6 +146,11 @@ def main():
         root_logger.addHandler(file_h)
 
     logger = logging.getLogger(__name__)
+    weight_decay = (
+        best_config.get("optimizer_weight_decay_pc", 0.001)
+        if best_config["optimizer_name"] == "adamw"
+        else best_config.get("optimizer_weight_decay", 0.01)
+    )
    
     config = GPTConfig(
         vocab_size = vocab_size,
@@ -166,7 +171,15 @@ def main():
         combined_internal_weight=best_config["combined_internal_weight"],
         combined_output_weight=best_config["combined_output_weight"],
         use_flash_attention=best_config["use_flash_attention"],
-        alpha = best_config["alpha"]
+        alpha = best_config["alpha"],
+        optimizer_name = best_config["optimizer_name"],
+        optimizer_beta1 = best_config["optimizer_beta1"],
+        optimizer_beta2 = best_config["optimizer_beta2"],
+        optimizer_eps = best_config["optimizer_eps"],
+        optimizer_weight_bound = best_config["optimizer_weight_bound"],
+        optimizer_momentum=best_config.get("optimizer_momentum", 0.9),
+        optimizer_weight_decay=weight_decay,
+    
     )
     
     # Create a separate logger for hyperparameters

--- a/training.py
+++ b/training.py
@@ -146,11 +146,7 @@ def main():
         root_logger.addHandler(file_h)
 
     logger = logging.getLogger(__name__)
-    weight_decay = (
-        best_config.get("optimizer_weight_decay_pc", 0.001)
-        if best_config["optimizer_name"] == "adamw"
-        else best_config.get("optimizer_weight_decay", 0.01)
-    )
+    weight_decay = best_config.get("optimizer_weight_decay", 0.1)
    
     config = GPTConfig(
         vocab_size = vocab_size,
@@ -177,7 +173,7 @@ def main():
         optimizer_beta2 = best_config["optimizer_beta2"],
         optimizer_eps = best_config["optimizer_eps"],
         optimizer_momentum=best_config.get("optimizer_momentum", 0.9),
-        optimizer_weight_decay=weight_decay,
+        optimizer_weight_decay=best_config.get("optimizer_weight_decay", 0.1),
     
     )
     

--- a/training.py
+++ b/training.py
@@ -176,7 +176,6 @@ def main():
         optimizer_beta1 = best_config["optimizer_beta1"],
         optimizer_beta2 = best_config["optimizer_beta2"],
         optimizer_eps = best_config["optimizer_eps"],
-        optimizer_weight_bound = best_config["optimizer_weight_bound"],
         optimizer_momentum=best_config.get("optimizer_momentum", 0.9),
         optimizer_weight_decay=weight_decay,
     

--- a/utils/config_utils.py
+++ b/utils/config_utils.py
@@ -13,11 +13,12 @@ def load_best_config():
         "lr", "inference_lr", "batch_size", "num_epochs", "internal_energy_fn_name",
         "output_energy_fn_name", "combined_internal_weight",
         "combined_output_weight", "use_flash_attention",
-        "optimizer_name", "optimizer_beta1", "optimizer_beta2", "optimizer_eps"
+        "optimizer_name", "optimizer_beta1", "optimizer_beta2", "optimizer_eps",
+        "optimizer_weight_decay", "optimizer_momentum"
     }
 
     fallback_values = {
-        "block_size": 64,
+       "block_size": 64,
         "peak_learning_rate": 0.009606017304857476,
         "warmup_steps": 59,
         "n_embed": 512,
@@ -38,7 +39,9 @@ def load_best_config():
         "optimizer_name": "adam",
         "optimizer_beta1": 0.9,
         "optimizer_beta2": 0.999,
-        "optimizer_eps": 1e-8
+        "optimizer_eps": 1e-8,
+        "optimizer_weight_decay": 0.1,
+        "optimizer_momentum": 0.9, #
     }
 
     config = {}

--- a/utils/config_utils.py
+++ b/utils/config_utils.py
@@ -18,30 +18,30 @@ def load_best_config():
     }
 
     fallback_values = {
-       "block_size": 64,
-        "peak_learning_rate": 0.009606017304857476,
-        "warmup_steps": 59,
-        "n_embed": 512,
+       "block_size": 208,
+        "peak_learning_rate": 0.003223786832283688,
+        "warmup_steps": 369,
+        "n_embed": 160,
         "dropout": 0.46876145412214615,
         "T": 2,
-        "num_heads": 32,
-        "n_blocks": 12,
+        "num_heads": 10,
+        "n_blocks": 3,
         "alpha": 0.5,
-        "lr": 0.0009606017304857476,
+        "lr": 0.003223786832283688,
         "inference_lr": 0.096,
         "batch_size": 8,
-        "num_epochs": 10,
+        "num_epochs": 5,
         "internal_energy_fn_name": "pc_e",
         "output_energy_fn_name": "pc_e",
         "combined_internal_weight": 0.8779955579743048,
         "combined_output_weight": 0.12200444202569516,
         "use_flash_attention": False,
-        "optimizer_name": "adam",
+        "optimizer_name": "sgd",
         "optimizer_beta1": 0.9,
         "optimizer_beta2": 0.999,
         "optimizer_eps": 1e-8,
-        "optimizer_weight_decay": 0.1,
-        "optimizer_momentum": 0.9, #
+        "optimizer_weight_decay": 0.01,
+        "optimizer_momentum": 0.9, #for sgd_momentum
     }
 
     config = {}

--- a/utils/config_utils.py
+++ b/utils/config_utils.py
@@ -13,7 +13,7 @@ def load_best_config():
         "lr", "inference_lr", "batch_size", "num_epochs", "internal_energy_fn_name",
         "output_energy_fn_name", "combined_internal_weight",
         "combined_output_weight", "use_flash_attention",
-        "optimizer_name", "optimizer_beta1", "optimizer_beta2", "optimizer_eps",
+        "optimizer_name", "output_optimizer_name", "optimizer_beta1", "optimizer_beta2", "optimizer_eps",
         "optimizer_weight_decay", "optimizer_momentum"
     }
 
@@ -37,6 +37,7 @@ def load_best_config():
         "combined_output_weight": 0.12200444202569516,
         "use_flash_attention": False,
         "optimizer_name": "sgd",
+        "output_optimizer_name": "adam",
         "optimizer_beta1": 0.9,
         "optimizer_beta2": 0.999,
         "optimizer_eps": 1e-8,

--- a/utils/config_utils.py
+++ b/utils/config_utils.py
@@ -12,7 +12,8 @@ def load_best_config():
         "dropout", "T", "num_heads", "n_blocks", "alpha",
         "lr", "inference_lr", "batch_size", "num_epochs", "internal_energy_fn_name",
         "output_energy_fn_name", "combined_internal_weight",
-        "combined_output_weight", "use_flash_attention"
+        "combined_output_weight", "use_flash_attention",
+        "optimizer_name", "optimizer_beta1", "optimizer_beta2", "optimizer_eps"
     }
 
     fallback_values = {
@@ -33,7 +34,11 @@ def load_best_config():
         "output_energy_fn_name": "pc_e",
         "combined_internal_weight": 0.8779955579743048,
         "combined_output_weight": 0.12200444202569516,
-        "use_flash_attention": False
+        "use_flash_attention": False,
+        "optimizer_name": "adam",
+        "optimizer_beta1": 0.9,
+        "optimizer_beta2": 0.999,
+        "optimizer_eps": 1e-8
     }
 
     config = {}

--- a/utils/optim/adam.py
+++ b/utils/optim/adam.py
@@ -1,0 +1,52 @@
+import torch
+
+
+def step_update(param, update, g1, g2, eta, beta1, beta2, time_step, eps):
+    """
+    Runs one step of Adam over a set of parameters given updates.
+
+    Args:
+        param: parameter tensor to change/adjust
+        update: update tensor to be applied to parameter tensor
+        g1: first moment tensor
+        g2: second moment tensor
+        eta: global step size
+        beta1: 1st moment control factor
+        beta2: 2nd moment control factor
+        time_step: current time step
+        eps: numerical stability coefficient
+
+    Returns:
+        adjusted parameter tensor, adjusted g1, adjusted g2
+    """
+    _g1 = beta1 * g1 + (1.0 - beta1) * update
+    _g2 = beta2 * g2 + (1.0 - beta2) * torch.square(update)
+    beta1_t = torch.tensor(beta1, device=param.device, dtype=param.dtype)
+    beta2_t = torch.tensor(beta2, device=param.device, dtype=param.dtype)
+    g1_unb = _g1 / (1.0 - torch.pow(beta1_t, time_step))
+    g2_unb = _g2 / (1.0 - torch.pow(beta2_t, time_step))
+    _param = param + eta * g1_unb / (torch.sqrt(g2_unb) + eps)
+    return _param, _g1, _g2
+
+
+def adam_step(opt_params, theta, updates, eta=0.001, beta1=0.9, beta2=0.999, eps=1e-8):
+    """Apply Adam update to a list of tensors."""
+    g1, g2, time_step = opt_params
+    time_step = time_step + 1
+    new_theta = []
+    new_g1 = []
+    new_g2 = []
+    for i in range(len(theta)):
+        px_i, g1_i, g2_i = step_update(theta[i], updates[i], g1[i], g2[i], eta, beta1, beta2, time_step, eps)
+        new_theta.append(px_i)
+        new_g1.append(g1_i)
+        new_g2.append(g2_i)
+    return (new_g1, new_g2, time_step), new_theta
+
+
+def adam_init(theta):
+    device = theta[0].device if len(theta) > 0 else torch.device("cpu")
+    time_step = torch.tensor(0.0, device=device)
+    g1 = [torch.zeros_like(theta[i]) for i in range(len(theta))]
+    g2 = [torch.zeros_like(theta[i]) for i in range(len(theta))]
+    return g1, g2, time_step

--- a/utils/optim/adamw.py
+++ b/utils/optim/adamw.py
@@ -1,0 +1,46 @@
+import torch
+
+def step_update(param, update, g1, g2, eta, beta1, beta2, time_step, eps, weight_decay):
+    _g1 = beta1 * g1 + (1.0 - beta1) * update
+    _g2 = beta2 * g2 + (1.0 - beta2) * torch.square(update)
+    
+    beta1_t = torch.tensor(beta1, device=param.device, dtype=param.dtype)
+    beta2_t = torch.tensor(beta2, device=param.device, dtype=param.dtype)
+    
+    g1_unb = _g1 / (1.0 - torch.pow(beta1_t, time_step).to(param.dtype))
+    g2_unb = _g2 / (1.0 - torch.pow(beta2_t, time_step).to(param.dtype))
+    
+    adam_step = eta * g1_unb / (torch.sqrt(g2_unb) + eps)
+
+    if weight_decay > 0.0:
+        _param = param + adam_step - eta * weight_decay * param
+    else:
+        _param = param + adam_step
+    return _param, _g1, _g2
+
+
+def adamw_step(opt_params, theta, updates, eta=0.001, beta1=0.9, beta2=0.999, eps=1e-8, weight_decay=0.01):
+    g1, g2, time_step = opt_params
+    time_step = time_step + 1
+    new_theta = []
+    new_g1 = []
+    new_g2 = []
+    
+    for i in range(len(theta)):
+        px_i, g1_i, g2_i = step_update(
+            theta[i], updates[i], g1[i], g2[i], 
+            eta, beta1, beta2, time_step, eps, weight_decay
+        )
+        new_theta.append(px_i)
+        new_g1.append(g1_i)
+        new_g2.append(g2_i)
+    
+    return (new_g1, new_g2, time_step), new_theta
+
+
+def adamw_init(theta):
+    device = theta[0].device if len(theta) > 0 else torch.device("cpu")
+    time_step = torch.tensor(0.0, device=device)
+    g1 = [torch.zeros_like(t) for t in theta]
+    g2 = [torch.zeros_like(t) for t in theta]
+    return g1, g2, time_step

--- a/utils/optim/adamw.py
+++ b/utils/optim/adamw.py
@@ -37,7 +37,6 @@ def adamw_step(opt_params, theta, updates, eta=0.001, beta1=0.9, beta2=0.999, ep
     
     return (new_g1, new_g2, time_step), new_theta
 
-
 def adamw_init(theta):
     device = theta[0].device if len(theta) > 0 else torch.device("cpu")
     time_step = torch.tensor(0.0, device=device)

--- a/utils/optim/optim_utils.py
+++ b/utils/optim/optim_utils.py
@@ -1,0 +1,160 @@
+import functools
+from typing import Dict, Any, Optional
+import torch
+
+from .sgd import sgd_step, sgd_init
+from .adam import adam_step, adam_init
+from .sgd_momentum import sgd_momentum_step, sgd_momentum_init
+from .adamw import adamw_step, adamw_init
+
+def get_opt_init_fn(opt="adam"):
+    return {
+        "adam": adam_init,
+        "sgd": sgd_init,
+        "sgd_momentum": sgd_momentum_init,   
+        "adamw": adamw_init,  
+    }[opt]
+
+
+def get_opt_step_fn(opt="adam", **kwargs):
+    # return {
+    #     "adam": functools.partial(adam_step, **kwargs),
+    #     "sgd": functools.partial(sgd_step, **kwargs),
+    # }[opt]
+    if opt == "sgd_momentum":
+        momentum = kwargs.pop("momentum", 0.9)
+        return functools.partial(sgd_momentum_step, momentum=momentum, **kwargs)
+    elif opt == "adamw":
+        weight_decay = kwargs.pop("weight_decay", 0.01)
+        return functools.partial(adamw_step, weight_decay=weight_decay, **kwargs)
+    elif opt == "adam":
+        return functools.partial(adam_step, **kwargs)
+    else:#sgd
+        return functools.partial(sgd_step, **kwargs)
+
+
+class PCOptimizer:
+    """Lightweight optimizer for predictive coding weight updates (Adam/SGD)."""
+
+    def __init__(
+        self,
+        opt_name: str = "adam",
+        beta1: float = 0.9,
+        beta2: float = 0.999,
+        eps: float = 1e-8,
+        sign_value: float = -1.0,
+        weight_bound: float = 0.0,
+        momentum: float = 0.9,
+        weight_decay: float = 0.01
+    ) -> None:
+        self.opt_name = opt_name.lower()
+        self.beta1 = float(beta1)
+        self.beta2 = float(beta2)
+        self.eps = float(eps)
+        self.sign_value = float(sign_value)
+        self.weight_bound = float(weight_bound)
+        self.momentum = float(momentum)
+        self.weight_decay = float(weight_decay)
+        self._state: Dict[int, Any] = {}
+
+    def _init_state(self, param: torch.Tensor):
+        init_fn = get_opt_init_fn(self.opt_name)
+        return init_fn([param])
+
+    def _sync_state_device(self, state, param: torch.Tensor):
+        # if self.opt_name == "adam":
+        #     g1, g2, time_step = state
+        #     if g1[0].device != param.device:
+        #         g1 = [g.to(param.device) for g in g1]
+        #     if g2[0].device != param.device:
+        #         g2 = [g.to(param.device) for g in g2]
+        #     if time_step.device != param.device:
+        #         time_step = time_step.to(param.device)
+        #     return g1, g2, time_step
+        # if state.device != param.device:
+        #     return state.to(param.device)
+        # return state
+        if isinstance(state, torch.Tensor):
+            #state is a single tensor -SGD time_step
+                if state.device != param.device:
+                    state = state.to(param.device)
+        elif isinstance(state, (tuple, list)):
+                #state is a tuple/list 
+                new_state = []
+                for item in state:
+                    if isinstance(item, torch.Tensor):
+                        #single tensor in the tuple
+                        if item.device != param.device:
+                            new_state.append(item.to(param.device))
+                        else:
+                            new_state.append(item)
+                    elif isinstance(item, (list, tuple)):
+                        # list of tensors g1, g2, momentum_buffers
+                        nested_new = []
+                        for nested_item in item:
+                            if isinstance(nested_item, torch.Tensor):
+                                if nested_item.device != param.device:
+                                    nested_new.append(nested_item.to(param.device))
+                                else:
+                                    nested_new.append(nested_item)
+                            else:
+                                nested_new.append(nested_item)
+                        new_state.append(type(item)(nested_new))
+                    else:
+                        # other types scalar for timesteps
+                        new_state.append(item)
+                state = type(state)(new_state)
+        return state
+
+    def step_param(
+        self,
+        param: torch.Tensor,
+        update: torch.Tensor,
+        lr: float,
+        clamp_value: Optional[float] = None,
+    ) -> None:
+        """Apply a single optimizer step to a parameter tensor."""
+        if update is None:
+            return
+
+        update = update.to(param.device, dtype=param.dtype)
+        lr = float(lr)
+
+        state = self._state.get(id(param))
+        if state is None:
+            state = self._init_state(param)
+        state = self._sync_state_device(state, param)
+
+        if self.opt_name == "adam":
+            step_fn = get_opt_step_fn(
+                self.opt_name,
+                eta=lr,
+                beta1=self.beta1,
+                beta2=self.beta2,
+                eps=self.eps,
+            )
+        elif self.opt_name == "sgd_momentum":
+            step_fn = get_opt_step_fn(
+                self.opt_name,
+                eta=lr,
+                momentum=self.momentum,
+            )
+        elif self.opt_name == "adamw":
+            step_fn = get_opt_step_fn(
+                self.opt_name, 
+                eta=lr,
+                weight_decay=self.weight_decay
+            )
+        else:
+            step_fn = get_opt_step_fn(self.opt_name, eta=lr)
+
+        with torch.no_grad():
+            new_state, new_params = step_fn(state, [param], [update])
+            new_param = new_params[0]
+            delta = new_param - param
+            if clamp_value is not None:
+                delta = torch.clamp(delta, -abs(clamp_value), abs(clamp_value))
+                new_param = param + delta
+            param.data.copy_(new_param)
+
+        self._state[id(param)] = new_state

--- a/utils/optim/optim_utils.py
+++ b/utils/optim/optim_utils.py
@@ -59,18 +59,7 @@ class PCOptimizer:
         return init_fn([param])
 
     def _sync_state_device(self, state, param: torch.Tensor):
-        # if self.opt_name == "adam":
-        #     g1, g2, time_step = state
-        #     if g1[0].device != param.device:
-        #         g1 = [g.to(param.device) for g in g1]
-        #     if g2[0].device != param.device:
-        #         g2 = [g.to(param.device) for g in g2]
-        #     if time_step.device != param.device:
-        #         time_step = time_step.to(param.device)
-        #     return g1, g2, time_step
-        # if state.device != param.device:
-        #     return state.to(param.device)
-        # return state
+       
         if isinstance(state, torch.Tensor):
             #state is a single tensor -SGD time_step
                 if state.device != param.device:
@@ -138,9 +127,12 @@ class PCOptimizer:
             )
         elif self.opt_name == "adamw":
             step_fn = get_opt_step_fn(
-                self.opt_name, 
+                self.opt_name,
                 eta=lr,
-                weight_decay=self.weight_decay
+                beta1=self.beta1,
+                beta2=self.beta2,
+                eps=self.eps,
+                weight_decay=self.weight_decay,
             )
         else:
             step_fn = get_opt_step_fn(self.opt_name, eta=lr)

--- a/utils/optim/optim_utils.py
+++ b/utils/optim/optim_utils.py
@@ -17,10 +17,7 @@ def get_opt_init_fn(opt="adam"):
 
 
 def get_opt_step_fn(opt="adam", **kwargs):
-    # return {
-    #     "adam": functools.partial(adam_step, **kwargs),
-    #     "sgd": functools.partial(sgd_step, **kwargs),
-    # }[opt]
+    
     if opt == "sgd_momentum":
         momentum = kwargs.pop("momentum", 0.9)
         return functools.partial(sgd_momentum_step, momentum=momentum, **kwargs)

--- a/utils/optim/optim_utils.py
+++ b/utils/optim/optim_utils.py
@@ -39,8 +39,6 @@ class PCOptimizer:
         beta1: float = 0.9,
         beta2: float = 0.999,
         eps: float = 1e-8,
-        sign_value: float = -1.0,
-        weight_bound: float = 0.0,
         momentum: float = 0.9,
         weight_decay: float = 0.01
     ) -> None:
@@ -48,8 +46,6 @@ class PCOptimizer:
         self.beta1 = float(beta1)
         self.beta2 = float(beta2)
         self.eps = float(eps)
-        self.sign_value = float(sign_value)
-        self.weight_bound = float(weight_bound)
         self.momentum = float(momentum)
         self.weight_decay = float(weight_decay)
         self._state: Dict[int, Any] = {}

--- a/utils/optim/sgd.py
+++ b/utils/optim/sgd.py
@@ -1,6 +1,5 @@
 import torch
 
-
 def step_update(param, update, eta):
     """
     Runs one step of SGD over a set of parameters given updates.

--- a/utils/optim/sgd.py
+++ b/utils/optim/sgd.py
@@ -1,0 +1,32 @@
+import torch
+
+
+def step_update(param, update, eta):
+    """
+    Runs one step of SGD over a set of parameters given updates.
+
+    Args:
+        eta: global step size to apply when adjusting parameters
+
+    Returns:
+        adjusted parameter tensor
+    """
+    _param = param + update * eta
+    return _param
+
+
+def sgd_step(opt_params, theta, updates, eta=0.001):
+    """Apply SGD update to a list of tensors."""
+    time_step = opt_params
+    time_step = time_step + 1
+    new_theta = []
+    for i in range(len(theta)):
+        px_i = step_update(theta[i], updates[i], eta)
+        new_theta.append(px_i)
+    new_opt_params = time_step
+    return new_opt_params, new_theta
+
+
+def sgd_init(theta):
+    device = theta[0].device if len(theta) > 0 else torch.device("cpu")
+    return torch.tensor(0.0, device=device)

--- a/utils/optim/sgd_momentum.py
+++ b/utils/optim/sgd_momentum.py
@@ -1,7 +1,7 @@
 import torch
 
 def step_update(param, update, momentum_buffer, eta, momentum):
-    v_new = momentum * momentum_buffer + update
+    v_new = momentum * momentum_buffer + (1 - momentum) * update
     _param = param + eta * v_new
     return _param, v_new
 

--- a/utils/optim/sgd_momentum.py
+++ b/utils/optim/sgd_momentum.py
@@ -5,7 +5,6 @@ def step_update(param, update, momentum_buffer, eta, momentum):
     _param = param + eta * v_new
     return _param, v_new
 
-
 def sgd_momentum_step(opt_params, theta, updates, eta=0.001, momentum=0.9):
     time_step, momentum_buffers = opt_params
     time_step = time_step + 1

--- a/utils/optim/sgd_momentum.py
+++ b/utils/optim/sgd_momentum.py
@@ -1,0 +1,33 @@
+import torch
+
+def step_update(param, update, momentum_buffer, eta, momentum):
+    v_new = momentum * momentum_buffer + update
+    _param = param + eta * v_new
+    return _param, v_new
+
+
+def sgd_momentum_step(opt_params, theta, updates, eta=0.001, momentum=0.9):
+    time_step, momentum_buffers = opt_params
+    time_step = time_step + 1
+    new_theta = []
+    new_momentum_buffers = []
+    
+    for i in range(len(theta)):
+        px_i, v_i = step_update(
+            theta[i], 
+            updates[i], 
+            momentum_buffers[i], 
+            eta, 
+            momentum
+        )
+        new_theta.append(px_i)
+        new_momentum_buffers.append(v_i)
+    
+    return (time_step, new_momentum_buffers), new_theta
+
+
+def sgd_momentum_init(theta):
+    device = theta[0].device if len(theta) > 0 else torch.device("cpu")
+    time_step = torch.tensor(0.0, device=device)
+    momentum_buffers = [torch.zeros_like(t) for t in theta]
+    return time_step, momentum_buffers

--- a/utils/pc_utils.py
+++ b/utils/pc_utils.py
@@ -4,6 +4,7 @@ import torch.nn.functional as F
 import gc
 from typing import Optional, Tuple, Any
 from utils.attention_utils import apply_flash_attention, apply_standard_attention
+from utils.optim.optim_utils import PCOptimizer
     
 def x_init(batch_size: int, seq_len: int, embedding_size: int, device: torch.device = None) -> torch.Tensor:
     device = device or (torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu"))
@@ -71,6 +72,7 @@ def step_embed(
     energy_fn_name: str,
     requires_update: bool,
     layer_norm: Optional[nn.Module] = None,
+    optimizer: Optional[PCOptimizer] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Predictive coding step for embedding layer.
@@ -88,9 +90,14 @@ def step_embed(
         with torch.no_grad():
             flat_input_ids = input_ids.reshape(-1)
             flat_update = error.reshape(-1, error.size(-1))
-            delta = torch.clamp(local_lr * flat_update, -0.01, 0.01)
-            word_layer.weight.data.index_add_(0, flat_input_ids, delta)
-            
+            if optimizer is not None:
+                update_word = torch.zeros_like(word_layer.weight)
+                update_word.index_add_(0, flat_input_ids, flat_update)
+                optimizer.step_param(word_layer.weight, update_word, local_lr, clamp_value=0.01)
+            else:
+                delta = torch.clamp(local_lr * flat_update, -0.01, 0.01)
+                word_layer.weight.data.index_add_(0, flat_input_ids, delta)
+
     return mu, mu_word, error
     
 def step_linear(
@@ -108,6 +115,7 @@ def step_linear(
     requires_update: bool,
     td_err: Optional[torch.Tensor],
     layer_norm: Optional[nn.Module], 
+    optimizer: Optional[PCOptimizer] = None,
    ):
     """
     Predictive coding step for linear-like layers.
@@ -145,7 +153,7 @@ def step_linear(
     if lateral_conn is not None:
         x = x + inference_lr * lateral_conn.forward(x, error)
         if requires_update:
-            lateral_conn.update_weights(x.detach())
+            lateral_conn.update_weights(x.detach(), optimizer=optimizer, clamp_value=0.01)
     else:
         x = x + inference_lr * error 
 
@@ -153,12 +161,19 @@ def step_linear(
     
     # parameter updates for the layer
     if requires_update:
-        delta_W = local_lr * torch.einsum("bsv, bsh -> vh", dE_dmu, x_input.detach())
-        delta_W = torch.clamp(delta_W, -0.01, 0.01)
-        layer.weight.data.add_(delta_W)
+        update_w = torch.einsum("bsv, bsh -> vh", dE_dmu, x_input.detach())
+        if optimizer is not None:
+            optimizer.step_param(layer.weight, update_w, local_lr, clamp_value=0.01)
+        else:
+            delta_W = torch.clamp(local_lr * update_w, -0.01, 0.01)
+            layer.weight.data.add_(delta_W)
         if layer.bias is not None:
-            delta_b = local_lr * dE_dmu.mean(dim=(0, 1))
-            layer.bias.data.add_(torch.clamp(delta_b, -0.01, 0.01))
+            update_b = dE_dmu.mean(dim=(0, 1))
+            if optimizer is not None:
+                optimizer.step_param(layer.bias, update_b, local_lr, clamp_value=0.01)
+            else:
+                delta_b = torch.clamp(local_lr * update_b, -0.01, 0.01)
+                layer.bias.data.add_(delta_b)
 
     return x, mu, bu_err
 
@@ -183,6 +198,7 @@ def step_attn(
     flash: bool = False,
     kv_cache: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     use_cache: bool = False,
+    optimizer: Optional[PCOptimizer] = None,
     ):
     """
     Predictive coding step for attention using Sine-Cosine RoPE.
@@ -302,7 +318,7 @@ def step_attn(
         x = x + inference_lr * delta_x
         
         if requires_update:
-            lateral_conn.update_weights(x.detach())
+             lateral_conn.update_weights(x.detach(), optimizer=optimizer, clamp_value=clamp_value)
     else:
         x = x + inference_lr * delta_x
 
@@ -310,33 +326,46 @@ def step_attn(
 
     if requires_update:
         with torch.no_grad():
+            update_q = torch.zeros_like(q_proj.weight)
+            update_k = torch.zeros_like(k_proj.weight)
+            update_v = torch.zeros_like(v_proj.weight)
+
+            update_b_q = torch.zeros_like(q_proj.bias) if q_proj.bias is not None else None
+            update_b_k = torch.zeros_like(k_proj.bias) if k_proj.bias is not None else None
+            update_b_v = torch.zeros_like(v_proj.bias) if v_proj.bias is not None else None
+
             for h in range(num_heads):
-                dW_q = torch.einsum("bte,btd->ed", x_norm, dE_dQ_raw[:, h])
-                dW_k = torch.einsum("bte,btd->ed", x_norm, dE_dK_raw[:, h])
-                dW_v = torch.einsum("bte,btd->ed", x_norm, dE_dV[:, h])
-                
-                dW_q = torch.clamp(dW_q, -0.01, 0.01)
-                dW_k = torch.clamp(dW_k, -0.01, 0.01)
-                dW_v = torch.clamp(dW_v, -0.01, 0.01)
-                
-                q_proj.weight.data[:, h*head_dim:(h+1)*head_dim] += local_lr * dW_q
-                k_proj.weight.data[:, h*head_dim:(h+1)*head_dim] += local_lr * dW_k
-                v_proj.weight.data[:, h*head_dim:(h+1)*head_dim] += local_lr * dW_v
-                
-                if q_proj.bias is not None:
-                    db_q = dE_dQ_raw[:, h].mean(dim=(0, 1))
-                    db_q = torch.clamp(db_q, -0.01, 0.01)
-                    q_proj.bias.data[h*head_dim:(h+1)*head_dim] += local_lr * db_q
-                
-                if k_proj.bias is not None:
-                    db_k = dE_dK_raw[:, h].mean(dim=(0, 1))
-                    db_k = torch.clamp(db_k, -0.01, 0.01)
-                    k_proj.bias.data[h*head_dim:(h+1)*head_dim] += local_lr * db_k
-                
-                if v_proj.bias is not None:
-                    db_v = dE_dV[:, h].mean(dim=(0, 1))
-                    db_v = torch.clamp(db_v, -0.01, 0.01)
-                    v_proj.bias.data[h*head_dim:(h+1)*head_dim] += local_lr * db_v
+                update_q[:, h*head_dim:(h+1)*head_dim] = torch.einsum("bte,btd->ed", x_norm, dE_dQ_raw[:, h])
+                update_k[:, h*head_dim:(h+1)*head_dim] = torch.einsum("bte,btd->ed", x_norm, dE_dK_raw[:, h])
+                update_v[:, h*head_dim:(h+1)*head_dim] = torch.einsum("bte,btd->ed", x_norm, dE_dV[:, h])
+
+                if update_b_q is not None:
+                    update_b_q[h*head_dim:(h+1)*head_dim] = dE_dQ_raw[:, h].mean(dim=(0, 1))
+                if update_b_k is not None:
+                    update_b_k[h*head_dim:(h+1)*head_dim] = dE_dK_raw[:, h].mean(dim=(0, 1))
+                if update_b_v is not None:
+                    update_b_v[h*head_dim:(h+1)*head_dim] = dE_dV[:, h].mean(dim=(0, 1))
+
+            if optimizer is not None:
+                optimizer.step_param(q_proj.weight, update_q, local_lr, clamp_value=0.01)
+                optimizer.step_param(k_proj.weight, update_k, local_lr, clamp_value=0.01)
+                optimizer.step_param(v_proj.weight, update_v, local_lr, clamp_value=0.01)
+                if update_b_q is not None:
+                    optimizer.step_param(q_proj.bias, update_b_q, local_lr, clamp_value=0.01)
+                if update_b_k is not None:
+                    optimizer.step_param(k_proj.bias, update_b_k, local_lr, clamp_value=0.01)
+                if update_b_v is not None:
+                    optimizer.step_param(v_proj.bias, update_b_v, local_lr, clamp_value=0.01)
+            else:
+                q_proj.weight.data.add_(torch.clamp(local_lr * update_q, -0.01, 0.01))
+                k_proj.weight.data.add_(torch.clamp(local_lr * update_k, -0.01, 0.01))
+                v_proj.weight.data.add_(torch.clamp(local_lr * update_v, -0.01, 0.01))
+                if update_b_q is not None:
+                    q_proj.bias.data.add_(torch.clamp(local_lr * update_b_q, -0.01, 0.01))
+                if update_b_k is not None:
+                    k_proj.bias.data.add_(torch.clamp(local_lr * update_b_k, -0.01, 0.01))
+                if update_b_v is not None:
+                    v_proj.bias.data.add_(torch.clamp(local_lr * update_b_v, -0.01, 0.01))
     new_kv_cache = (K.detach(), V.detach()) if use_cache else None
     return x, mu, bu_err, new_kv_cache
 

--- a/utils/pc_utils.py
+++ b/utils/pc_utils.py
@@ -335,16 +335,16 @@ def step_attn(
             update_b_v = torch.zeros_like(v_proj.bias) if v_proj.bias is not None else None
 
             for h in range(num_heads):
-                update_q[:, h*head_dim:(h+1)*head_dim] = torch.einsum("bte,btd->ed", x_norm, dE_dQ_raw[:, h])
-                update_k[:, h*head_dim:(h+1)*head_dim] = torch.einsum("bte,btd->ed", x_norm, dE_dK_raw[:, h])
-                update_v[:, h*head_dim:(h+1)*head_dim] = torch.einsum("bte,btd->ed", x_norm, dE_dV[:, h])
+                update_q[:, h*head_dim:(h+1)*head_dim] = torch.clamp(torch.einsum("bte,btd->ed", x_norm, dE_dQ_raw[:, h]), -0.01, 0.01)
+                update_k[:, h*head_dim:(h+1)*head_dim] = torch.clamp(torch.einsum("bte,btd->ed", x_norm, dE_dK_raw[:, h]), -0.01, 0.01)
+                update_v[:, h*head_dim:(h+1)*head_dim] = torch.clamp(torch.einsum("bte,btd->ed", x_norm, dE_dV[:, h]), -0.01, 0.01)
 
                 if update_b_q is not None:
-                    update_b_q[h*head_dim:(h+1)*head_dim] = dE_dQ_raw[:, h].mean(dim=(0, 1))
+                    update_b_q[h*head_dim:(h+1)*head_dim] = torch.clamp(dE_dQ_raw[:, h].mean(dim=(0, 1)), -0.01, 0.01)
                 if update_b_k is not None:
-                    update_b_k[h*head_dim:(h+1)*head_dim] = dE_dK_raw[:, h].mean(dim=(0, 1))
+                    update_b_k[h*head_dim:(h+1)*head_dim] = torch.clamp(dE_dK_raw[:, h].mean(dim=(0, 1)), -0.01, 0.01)
                 if update_b_v is not None:
-                    update_b_v[h*head_dim:(h+1)*head_dim] = dE_dV[:, h].mean(dim=(0, 1))
+                    update_b_v[h*head_dim:(h+1)*head_dim] = torch.clamp(dE_dV[:, h].mean(dim=(0, 1)), -0.01, 0.01)
 
             if optimizer is not None:
                 optimizer.step_param(q_proj.weight, update_q, local_lr, clamp_value=0.01)


### PR DESCRIPTION
### **Summary**

This PR introduces a pluggable optimizer system for PC weight and bias updates.Previously, all layers used a hardcoded SGD-equivalent rule:
` ΔW = clamp(lr × gradient, -0.01, 0.01)`                                                                                       
Now any layer can use `Adam`, `AdamW`, `plain SGD`, or `SGD-momentum`, configured via a single `optimizer_name` key in the hyperparameter config.    

### **Main Changes**

- Implementation of SGD,SGD with momentum,Adam and AdamW optimizers and PCOptimizer Class- [af7f895
](https://github.com/iCog-Labs-Dev/PC-Transformers/commit/af7f8955a6c615b044000fb81a824e5574b6ccc9)
- Instantiate PCOptimizer in PCLayer - [64b3bed
](https://github.com/iCog-Labs-Dev/PC-Transformers/commit/64b3bede9852aa87c7803e17fa5ee7a31cee861e)
- Integrate PCOptimizer into step_embed,step_linear and step_attn- [08abe8
](https://github.com/iCog-Labs-Dev/PC-Transformers/commit/c08abe8e763e71eb33654463b4a3e33b24461dec)
- Add optimizer config at all entry points in GPTConfig - [3c3a9aa
](https://github.com/iCog-Labs-Dev/PC-Transformers/commit/3c3a9aaeda286ea5b94475b4d78c55efd2d964d7)
- Pass optimizer config to the PCLayer Instance in:
   - Embedding Layer- [2ff52e
](https://github.com/iCog-Labs-Dev/PC-Transformers/commit/52ff52e27b94e1ee2e38c873fb6595987e1a95fb)
   - Attention Layer- [3c472ca
](https://github.com/iCog-Labs-Dev/PC-Transformers/commit/3c472caca6dc5b50a9ccd415abfd8c8cc3f1a30c)
   - MLP Layer- [59dc4f5
](https://github.com/iCog-Labs-Dev/PC-Transformers/commit/59dc4f5cc4027de4a110cd6a1d0a5e1829f4beba)
   - Output Layer - [9673be4
](https://github.com/iCog-Labs-Dev/PC-Transformers/commit/9673be45ddbd4983110d8f62d5f13eba0cc939da)



                                     