### PR TITLE
DDP Synchronization 

### DIFF
--- a/benchmark_T.py
+++ b/benchmark_T.py
@@ -14,9 +14,9 @@ from data_preparation.config import vocab_size
 
 def benchmark_T(T_values=[2, 3, 4, 5, 6, 8, 10], num_epochs=5):
     """Run controlled experiments varying only T (inference iterations)"""
-    local_rank, device, use_ddp = setup_device()
+    local_rank, device, use_distributed = setup_device()
     
-    if use_ddp and not dist.is_initialized():
+    if use_distributed and not dist.is_initialized():
         dist.init_process_group(backend="nccl")
     
     # Load best config
@@ -60,12 +60,12 @@ def benchmark_T(T_values=[2, 3, 4, 5, 6, 8, 10], num_epochs=5):
         
         # Initialize model
         model = PCTransformer(config).to(device)
-        if use_ddp:
-            from torch.nn.parallel import DistributedDataParallel as DDP
-            model = DDP(model, device_ids=[local_rank], output_device=local_rank)
+        if use_distributed:
+            for param in model.parameters():
+                dist.broadcast(param.data, src=0)
         
         # Get data loaders
-        train_loader, valid_loader, _ = get_loaders(batch_size=config.batch_size, block_size=config.block_size, distributed=use_ddp)
+        train_loader, valid_loader, _ = get_loaders(batch_size=config.batch_size, block_size=config.block_size, distributed=use_distributed)
         
         # Train for specified epochs
         train_energies = []
@@ -124,7 +124,7 @@ def benchmark_T(T_values=[2, 3, 4, 5, 6, 8, 10], num_epochs=5):
         # Create plots
         plot_T_benchmark(results, output_dir)
     
-    if use_ddp:
+    if use_distributed:
         dist.destroy_process_group()
 
 def plot_T_benchmark(results, output_dir):

--- a/benchmark_blocks.py
+++ b/benchmark_blocks.py
@@ -15,9 +15,9 @@ from model_architecture.pc_t_model import PCTransformer
 
 def benchmark_blocks(block_values=[2, 3, 4, 5, 6], num_epochs=5):
     """Run controlled experiments varying only n_blocks"""
-    local_rank, device, use_ddp = setup_device()
+    local_rank, device, use_distributed = setup_device()
     
-    if use_ddp and not dist.is_initialized():
+    if use_distributed and not dist.is_initialized():
         dist.init_process_group(backend="nccl")
     
     # Load best config
@@ -59,12 +59,12 @@ def benchmark_blocks(block_values=[2, 3, 4, 5, 6], num_epochs=5):
         
         # Initialize model
         model = PCTransformer(config).to(device)
-        if use_ddp:
-            from torch.nn.parallel import DistributedDataParallel as DDP
-            model = DDP(model, device_ids=[local_rank], output_device=local_rank)
+        if use_distributed:
+            for param in model.parameters():
+                dist.broadcast(param.data, src=0)
         
         # Get data loaders
-        train_loader, valid_loader, _ = get_loaders(batch_size=config.batch_size, block_size=config.block_size, distributed=use_ddp)
+        train_loader, valid_loader, _ = get_loaders(batch_size=config.batch_size, block_size=config.block_size, distributed=use_distributed)
         
         # Train for specified epochs
         train_energies = []
@@ -120,7 +120,7 @@ def benchmark_blocks(block_values=[2, 3, 4, 5, 6], num_epochs=5):
         # Create plots
         plot_blocks_benchmark(results, output_dir)
     
-    if use_ddp:
+    if use_distributed:
         dist.destroy_process_group()
 
 def plot_blocks_benchmark(results, output_dir):

--- a/eval.py
+++ b/eval.py
@@ -9,7 +9,6 @@ import torch.nn.functional as F
 from utils.model_utils import load_model
 from utils.config_utils import load_best_config
 from utils.model_utils import set_seed
-from torch.nn.parallel import DistributedDataParallel as DDP
 import torch.distributed as dist
 from utils.device_utils import setup_device
 import argparse
@@ -21,7 +20,7 @@ This script evaluates the performance of the predictive coding transformer model
 Usage: torchrun --nproc-per-node=<NUM_GPU> eval.py
 
 """
-local_rank, device, use_ddp = setup_device()
+local_rank, device, use_distributed = setup_device()
 
 def evaluate(model, config, dataloader, max_batches=None, device = None):
     model.eval()
@@ -29,8 +28,7 @@ def evaluate(model, config, dataloader, max_batches=None, device = None):
     batch_count = 0
     total_ce_loss = 0.0
     
-    base_model = model.module if hasattr(model, 'module') else model
-    output_pc_layer = base_model.output.pc_layer
+    output_pc_layer = model.output.pc_layer
     
     if local_rank == 0:
         if max_batches is None:
@@ -100,7 +98,7 @@ def main():
     parser.add_argument('--flash', action='store_true', help='Enable FlashAttention for attention layers')
     args = parser.parse_args()
 
-    if use_ddp and not dist.is_initialized():
+    if use_distributed and not dist.is_initialized():
         dist.init_process_group(backend="nccl")
 
     print(f"[Rank {local_rank}] Using device: {device}")    
@@ -138,9 +136,11 @@ def main():
     model_path = "checkpoints/final_model.pt"
     model = load_model(model_path, config)
     model = model.to(device)
-    if use_ddp:
-        model = DDP(model, device_ids=[local_rank], output_device=local_rank)
-    _, _, test_loader = get_loaders(batch_size=config.batch_size, block_size=config.block_size, distributed = use_ddp)
+    if use_distributed:
+        for param in model.parameters():
+            dist.broadcast(param.data, src=0)
+
+    _, _, test_loader = get_loaders(batch_size=config.batch_size, block_size=config.block_size, distributed = use_distributed)
 
     # Max batches can be set to limit evaluation, or None for full dataset
     start_time = time.time()
@@ -151,7 +151,7 @@ def main():
     if not dist.is_initialized() or dist.get_rank() == 0:
         print(f"Evaluation completed in {elapsed:.2f} seconds")  
         
-    if use_ddp and dist.is_initialized(): 
+    if use_distributed and dist.is_initialized(): 
         dist.barrier()
         dist.destroy_process_group()
 

--- a/generate_text.py
+++ b/generate_text.py
@@ -6,7 +6,6 @@ from utils.config_utils import load_best_config
 from utils.model_utils import set_seed
 import torch.nn.functional as F
 from data_preparation.dataloader import get_loaders
-from torch.nn.parallel import DistributedDataParallel as DDP
 import torch.distributed as dist
 from utils.device_utils import setup_device
 import argparse
@@ -19,7 +18,7 @@ It takes a prompt, generates new tokens, and prints the prompt, target, and gene
 Usage: torchrun --nproc-per-node=<NUM_GPU> generate_text.py
 
 """
-local_rank, device, use_ddp = setup_device()
+local_rank, device, use_distributed = setup_device()
 
 def generate_text(model, config, input_ids, max_new_tokens, temperature, device = None, use_cache=True):
     model.eval()
@@ -79,7 +78,7 @@ def main():
     parser.add_argument('--flash', action='store_true', help='Enable FlashAttention for attention layers')
     args = parser.parse_args()
 
-    if use_ddp and not dist.is_initialized():
+    if use_distributed and not dist.is_initialized():
         dist.init_process_group(backend="nccl")
 
     print(f"[Rank {local_rank}] Using device: {device}")
@@ -118,15 +117,17 @@ def main():
     model_path = "checkpoints/final_model.pt"
     model = load_model(model_path, config)
     model = model.to(device)
-    if use_ddp:
-        model = DDP(model, device_ids=[local_rank], output_device=local_rank)
+    
+    if use_distributed:
+        for param in model.parameters():
+            dist.broadcast(param.data, src=0)
 
     if not dist.is_initialized() or dist.get_rank() == 0:
         decoded_preds, decoded_targets = text_generation(model, config, device, max_samples=2, use_cache=True)
         # if decoded_preds and decoded_targets and local_rank == 0:
         #     compute_text_metrics(decoded_preds, decoded_targets)
     
-    if use_ddp and dist.is_initialized():
+    if use_distributed and dist.is_initialized():
         dist.barrier()
         dist.destroy_process_group()
 

--- a/model_architecture/pc_t_model.py
+++ b/model_architecture/pc_t_model.py
@@ -37,10 +37,10 @@ class PCTransformer(nn.Module):
         """
         for block in self.blocks:
             block.attn.pc_qkv.register_lateral("attn", block.attn.q.in_features)
-            block.attn.pc_output.register_lateral("linear", block.attn.output.in_features)
+            block.attn.pc_output.register_lateral("linear_attn", block.attn.output.in_features)
             block.mlp.pc_layer1.register_lateral("fc1", block.mlp.fc1.in_features)
-            block.mlp.pc_layer2.register_lateral("linear", block.mlp.fc2.in_features)
-        self.output.pc_layer.register_lateral("linear", self.output.output.in_features)
+            block.mlp.pc_layer2.register_lateral("fc2", block.mlp.fc2.in_features)
+        self.output.pc_layer.register_lateral("linear_output", self.output.output.in_features)
 
         for module in self.modules():
             if hasattr(module, 'W_latents'):

--- a/training.py
+++ b/training.py
@@ -16,7 +16,7 @@ from eval import evaluate
 from visualization import plot_metrics
 import torch.distributed as dist
 from torch.nn.parallel import DistributedDataParallel as DDP
-from utils.device_utils import setup_device, cleanup_memory
+from utils.device_utils import setup_device, cleanup_memory, sync_pc_weights
 import json
 import logging
 from data_preparation.config import vocab_size
@@ -64,6 +64,9 @@ def train(model, dataloader, config, global_step, device, logger):
         global_step += 1
             
         logits = model(target_ids, input_ids)
+
+        sync_pc_weights(model)
+
         ce_loss = F.cross_entropy(
             logits.view(-1, logits.size(-1)),
             target_ids.view(-1),
@@ -196,13 +199,17 @@ def main():
         param_logger.info("Saving the hyperparameters configurations:")
         param_logger.info(config_json)
 
-    model = PCTransformer(config).to(device)
-    if use_ddp:
-        model = DDP(model, device_ids=[local_rank], 
-                    output_device=local_rank, 
-                    find_unused_parameters=True)
+    model = PCTransformer(config)
+    model.register_all_lateral_weights()
+    model = model.to(device)
 
-        model.module.register_all_lateral_weights()
+    if use_ddp:
+        model = DDP(
+            model, 
+            device_ids=[local_rank], 
+            output_device=local_rank, 
+            find_unused_parameters=True
+        )
 
     train_loader, valid_loader, _ = get_loaders(batch_size=config.batch_size, block_size=config.block_size, distributed=use_ddp)
     

--- a/training.py
+++ b/training.py
@@ -15,7 +15,6 @@ from utils.model_utils import set_seed
 from eval import evaluate
 from visualization import plot_metrics
 import torch.distributed as dist
-from torch.nn.parallel import DistributedDataParallel as DDP
 from utils.device_utils import setup_device, cleanup_memory, sync_pc_weights
 import json
 import logging
@@ -35,8 +34,7 @@ def train(model, dataloader, config, global_step, device, logger):
     total_energy = 0.0
     batch_count = 0
 
-    base_model = model.module if hasattr(model, 'module') else model
-    output_pc_layer = base_model.output.pc_layer
+    output_pc_layer = model.output.pc_layer
         
     for batch_idx, batch in enumerate(dataloader):
         input_ids = batch["input_ids"].to(device)
@@ -121,8 +119,8 @@ def train(model, dataloader, config, global_step, device, logger):
 
 def main():
     set_seed(42)
-    local_rank, device, use_ddp = setup_device()
-    if use_ddp and not dist.is_initialized():
+    local_rank, device, use_distributed = setup_device()
+    if use_distributed and not dist.is_initialized():
         dist.init_process_group(backend="nccl")
 
     rank = dist.get_rank() if dist.is_initialized() else 0
@@ -203,15 +201,11 @@ def main():
     model.register_all_lateral_weights()
     model = model.to(device)
 
-    if use_ddp:
-        model = DDP(
-            model, 
-            device_ids=[local_rank], 
-            output_device=local_rank, 
-            find_unused_parameters=True
-        )
+    if use_distributed:
+        for param in model.parameters():
+            dist.broadcast(param.data, src=0)
 
-    train_loader, valid_loader, _ = get_loaders(batch_size=config.batch_size, block_size=config.block_size, distributed=use_ddp)
+    train_loader, valid_loader, _ = get_loaders(batch_size=config.batch_size, block_size=config.block_size, distributed=use_distributed)
     
     global_step = 0
     train_energies = []
@@ -254,10 +248,9 @@ def main():
 
             if (epoch + 1) % 5 == 0 or epoch == config.num_epochs - 1:
                 os.makedirs("checkpoints", exist_ok=True)
-                # Get the underlying model (handle both DDP and non-DDP cases)
-                model_to_save = model.module if hasattr(model, 'module') else model
+                # Get the underlying model (handle both single and multi-gpu cases)
                 checkpoint = {
-                    'model_state_dict': model_to_save.state_dict(),
+                    'model_state_dict': model.state_dict(),
                 }
                 checkpoint_path = f'checkpoints/model_epoch_{epoch+1}.pt'
                 torch.save(checkpoint, checkpoint_path)
@@ -272,10 +265,9 @@ def main():
         )
 
         os.makedirs("checkpoints", exist_ok=True)
-        # Get the underlying model (handle both DDP and non-DDP cases)
-        model_to_save = model.module if hasattr(model, 'module') else model
+        # Get the underlying model (handle both single and multi-gpu cases)
         final_checkpoint = {
-            'model_state_dict': model_to_save.state_dict(),
+            'model_state_dict': model.state_dict(),
         }
         torch.save(final_checkpoint, 'checkpoints/final_model.pt')
         total_time = time.time() - start_time
@@ -284,7 +276,7 @@ def main():
         logger.info("========== Training completed ==========")
 
     # dist.destroy_process_group()
-    if use_ddp and dist.is_initialized():
+    if use_distributed and dist.is_initialized():
         dist.destroy_process_group()
 
 

--- a/tuning/tune_model.py
+++ b/tuning/tune_model.py
@@ -11,6 +11,9 @@ sys.path.append(str(project_root))
 import torch
 import optuna
 from optuna.storages import JournalStorage, JournalFileStorage
+import torch.distributed as dist
+from torch.nn.parallel import DistributedDataParallel as DDP
+from utils.device_utils import setup_device
 
 from training import train
 from eval import evaluate
@@ -27,6 +30,23 @@ optuna.logging.set_verbosity(optuna.logging.WARNING)
 logging.getLogger('optuna').setLevel(logging.WARNING)
 
 ENERGY_STABILITY_THRESHOLD = 300
+
+def get_rank():
+    """Return current process rank; defaults to 0 if distributed is not initialized."""
+    return dist.get_rank() if dist.is_available() and dist.is_initialized() else 0
+
+def is_rank0():
+    """Check if current process is rank 0 (main process)."""
+    return get_rank() == 0
+
+def broadcast_object(obj):
+    """Broadcast a Python object from rank 0 to all processes; returns the synced object."""
+    if not dist.is_available() or not dist.is_initialized():
+        return obj
+
+    obj_list = [obj]
+    dist.broadcast_object_list(obj_list, src=0)
+    return obj_list[0]
 
 def define_search_space(trial):
     """
@@ -99,7 +119,7 @@ def define_search_space_phase2(trial, best_params):
         "dropout": trial.suggest_float("dropout", max(0.0, dropout - 0.02), min(0.15, dropout + 0.02)),
     }
 
-def create_model(params):
+def create_model(params, device, use_ddp=False, local_rank=0):
     """
     Assembles the model, config, and data for a single trial.
 
@@ -120,8 +140,6 @@ def create_model(params):
             - device: The hardware device (CPU/GPU) being used
 
     """
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    
     config = GPTConfig(
         vocab_size=vocab_size,
         block_size= params["block_size"],
@@ -147,11 +165,98 @@ def create_model(params):
     model = PCTransformer(config)
     model.register_all_lateral_weights() 
     model = model.to(device)
-    train_loader, valid_loader, _ = get_loaders(batch_size=params["batch_size"], block_size=params["block_size"], distributed=False)
+
+    if use_ddp:
+        model = DDP(
+            model,
+            device_ids=[local_rank],
+            output_device=local_rank,
+            find_unused_parameters=True,
+        )
+
+    train_loader, valid_loader, _ = get_loaders(
+        batch_size=params["batch_size"], 
+        block_size=params["block_size"], 
+        distributed=use_ddp
+    )
     
     return model, config, train_loader, valid_loader, device
 
-def run_phase1_trial(trial):
+def run_trial_with_params(params, trial_number, device, use_ddp, local_rank):
+    """Run one training/evaluation trial with given params; returns metrics or instability flag (DDP-aware)."""
+    model = None
+
+    try:
+        model, config, train_loader, valid_loader, device = create_model(
+            params,
+            device=device,
+            use_ddp=use_ddp,
+            local_rank=local_rank,
+        )
+
+        if hasattr(train_loader, "sampler") and isinstance(
+            train_loader.sampler,
+            torch.utils.data.DistributedSampler,
+        ):
+            train_loader.sampler.set_epoch(trial_number)
+
+        start_time = time.time()
+
+        train_energy, train_ppl, _ = train(
+            model,
+            train_loader,
+            config,
+            global_step=0,
+            device=device,
+            logger=None,
+        )
+
+        unstable = (
+            torch.isnan(torch.tensor(train_energy)).item()
+            or train_energy > ENERGY_STABILITY_THRESHOLD
+        )
+
+        if use_ddp:
+            unstable_tensor = torch.tensor(int(unstable), device=device)
+            dist.all_reduce(unstable_tensor, op=dist.ReduceOp.MAX)
+            unstable = bool(unstable_tensor.item())
+
+        if unstable:
+            return {
+                "unstable": True,
+                "train_energy": train_energy,
+            }
+
+        val_energy, val_ppl = evaluate(
+            model,
+            config,
+            valid_loader,
+            max_batches=10,
+            device=device,
+        )
+
+        if use_ddp:
+            metrics = torch.tensor([val_energy, val_ppl], dtype=torch.float32, device=device)
+            dist.all_reduce(metrics, op=dist.ReduceOp.SUM)
+            metrics /= dist.get_world_size()
+            val_energy, val_ppl = metrics.tolist()
+
+        return {
+            "unstable": False,
+            "train_energy": train_energy,
+            "train_ppl": train_ppl,
+            "val_energy": val_energy,
+            "val_ppl": val_ppl,
+            "time": time.time() - start_time,
+        }
+
+    finally:
+        if model is not None:
+            del model
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+def run_phase1_trial(trial, device, use_ddp, local_rank):
     """
     Phase 1 Trial Execution
     
@@ -166,49 +271,47 @@ def run_phase1_trial(trial):
     Returns:
         float: The validation energy score (Optuna attempts to minimize this).
     """
-    try:
-        params = define_search_space(trial)
-        print(f"[Energy Phase] Trial {trial.number} | params: {params}")
+    params = define_search_space(trial)
 
-        model, config, train_loader, valid_loader, device = create_model(params)
-        start_time = time.time()
+    if use_ddp:
+        broadcast_object({
+            "cmd": "trial",
+            "trial_number": trial.number,
+            "params": params,
+        })
 
-        try:
-            # We use the internal train function. If it explodes, it will return high energy or NaN.
-            train_energy, train_ppl, _ = train(model, train_loader, config, global_step=0, device=device, logger=None)
-            
-            if torch.isnan(torch.tensor(train_energy)) or train_energy > ENERGY_STABILITY_THRESHOLD:
-                reason = f"Unstable Energy: {train_energy}"
-                trial.set_user_attr("prune_reason", reason)
-                print(f"  {reason}")
-                raise optuna.TrialPruned()
+    print(f"[Energy Phase] Trial {trial.number} | params: {params}")
 
-            # Evaluate on a subset of validation data
-            val_energy, val_ppl = evaluate(model, config, valid_loader, max_batches=10, device=device)
+    result = run_trial_with_params(
+        params=params,
+        trial_number=trial.number,
+        device=device,
+        use_ddp=use_ddp,
+        local_rank=local_rank,
+    )
 
-        except Exception as e:
-            if not isinstance(e, optuna.TrialPruned):
-                reason = f"Execution failed: {e}"
-                trial.set_user_attr("prune_reason", reason)
-                print(f"  {reason}")
-            raise optuna.TrialPruned()
+    if result["unstable"]:
+        reason = f"Unstable Energy: {result['train_energy']}"
+        trial.set_user_attr("prune_reason", reason)
+        print(f"  {reason}")
+        raise optuna.TrialPruned()
+    
+    trial.set_user_attr("val_ppl", float(result["val_ppl"]))
+    trial.set_user_attr("time", result["time"])
 
-        total_time = time.time() - start_time
-        
-        trial.set_user_attr("val_ppl", float(val_ppl))
-        trial.set_user_attr("time", total_time)
-        for key, value in params.items():
-            trial.set_user_attr(f"param_{key}", value)
+    for key, value in params.items():
+        trial.set_user_attr(f"param_{key}", value)
 
-        print(f"Trial {trial.number} Complete | Val Energy={val_energy:.4f} | Val PPL={val_ppl:.4f} | Time={total_time:.1f}s")
-        return float(val_energy)
+    print(
+        f"Trial {trial.number} Complete | "
+        f"Val Energy={result['val_energy']:.4f} | "
+        f"Val PPL={result['val_ppl']:.4f} | "
+        f"Time={result['time']:.1f}s"
+    )
 
-    finally:
-        if 'model' in locals():
-            del model
-        torch.cuda.empty_cache()
+    return float(result["val_energy"])
 
-def run_phase2_trial(trial, best_params):
+def run_phase2_trial(trial, best_params, device, use_ddp, local_rank):
     """
     Phase 2 Trial Execution
     
@@ -227,49 +330,63 @@ def run_phase2_trial(trial, best_params):
     continuous_params = define_search_space_phase2(trial, best_params)
     params = {**best_params, **continuous_params}
     
+    if use_ddp:
+        broadcast_object({
+            "cmd": "trial",
+            "trial_number": trial.number,
+            "params": params,
+        })
+
     tuning_params = {k: v for k, v in params.items() if k in ['lr', 'inference_lr', 'dropout']}
     print(f"[PPL Phase - Continuous Only] Trial {trial.number} | params: {tuning_params}")
     print(f"[PPL Phase - Fixed] Architecture: n_blocks={params['n_blocks']}, num_heads={params['num_heads']}, "
           f"n_embed={params['n_embed']}, T={params['T']}, block_size={params['block_size']}")
 
-    try:
-        model, config, train_loader, valid_loader, device = create_model(params)
-        start_time = time.time()
+    result = run_trial_with_params(
+        params=params,
+        trial_number=trial.number,
+        device=device,
+        use_ddp=use_ddp,
+        local_rank=local_rank,
+    )
 
-        try:
-            train_energy, train_ppl, _ = train(model, train_loader, config, global_step=0, device=device, logger=None)
-            
-            if torch.isnan(torch.tensor(train_energy)) or train_energy > ENERGY_STABILITY_THRESHOLD:
-                reason = f"Unstable Energy during Phase 2: {train_energy}"
-                trial.set_user_attr("prune_reason", reason)
-                print(f"  {reason}")
-                raise optuna.TrialPruned()
+    if result["unstable"]:
+        reason = f"Unstable Energy during Phase 2: {result['train_energy']}"
+        trial.set_user_attr("prune_reason", reason)
+        print(f"  {reason}")
+        raise optuna.TrialPruned()
 
-            val_energy, val_ppl = evaluate(model, config, valid_loader, max_batches=10, device=device)
+    trial.set_user_attr("val_energy", float(result["val_energy"]))
+    trial.set_user_attr("time", result["time"])
 
-        except Exception as e:
-            if not isinstance(e, optuna.TrialPruned):
-                reason = f"Execution failed: {e}"
-                trial.set_user_attr("prune_reason", reason)
-                print(f"  {reason}")
-            raise optuna.TrialPruned()
+    for key, value in params.items():
+        trial.set_user_attr(f"param_{key}", value)
 
-        total_time = time.time() - start_time
-        
-        trial.set_user_attr("val_energy", float(val_energy))
-        trial.set_user_attr("time", total_time)
-        for key, value in params.items():
-            trial.set_user_attr(f"param_{key}", value)
+    print(
+        f"Trial {trial.number} Complete | "
+        f"Final Val PPL={result['val_ppl']:.4f} | "
+        f"Time={result['time']:.1f}s"
+    )
 
-        print(f"Trial {trial.number} Complete | Final Val PPL={val_ppl:.4f} | Time={total_time:.1f}s")
-        return float(val_ppl)
+    return float(result["val_ppl"])
 
-    finally:
-        if 'model' in locals():
-            del model
-        torch.cuda.empty_cache()
+def ddp_worker_loop(device, use_ddp, local_rank):
+    """Listen for broadcasted commands and execute trials until a stop signal is received."""
+    while True:
+        command = broadcast_object(None)
 
-def run_tuning_pipeline():
+        if command["cmd"] == "stop":
+            break
+
+        run_trial_with_params(
+            params=command["params"],
+            trial_number=command["trial_number"],
+            device=device,
+            use_ddp=use_ddp,
+            local_rank=local_rank,
+        )
+
+def run_tuning_pipeline(device, use_ddp, local_rank):
     """
     Coordinates the two-phase tuning pipeline
 
@@ -300,7 +417,17 @@ def run_tuning_pipeline():
         pruner=optuna.pruners.HyperbandPruner(min_resource=1, max_resource=15, reduction_factor=2)
     )
 
-    study_energy.optimize(run_phase1_trial, n_trials=50, n_jobs=1, show_progress_bar=False)
+    study_energy.optimize(
+        lambda trial: run_phase1_trial(
+            trial,
+            device=device,
+            use_ddp=use_ddp,
+            local_rank=local_rank,
+        ),
+        n_trials=50,
+        n_jobs=1,
+        show_progress_bar=False,
+    )
 
     if study_energy.best_trial:
         best_energy = study_energy.best_value
@@ -319,6 +446,8 @@ def run_tuning_pipeline():
         for key in ['lr', 'inference_lr', 'dropout']:
             print(f"  {key}: {best_params.get(key)}")
     else:
+        if use_ddp:
+            broadcast_object({"cmd": "stop"})
         return None
 
     print(f"\n{'='*60}")
@@ -345,7 +474,13 @@ def run_tuning_pipeline():
     print(f"Resuming with {len(study_ppl.trials)} previous Phase 2 trials")
 
     def phase2_trial_wrapper(trial):
-        return run_phase2_trial(trial, best_params)
+        return run_phase2_trial(
+            trial,
+            best_params,
+            device=device,
+            use_ddp=use_ddp,
+            local_rank=local_rank,
+        )
 
     study_ppl.optimize(phase2_trial_wrapper, n_trials=50, n_jobs=1, show_progress_bar=False)
 
@@ -388,7 +523,10 @@ def run_tuning_pipeline():
                 f.write(f"{key} = {value}\n")
         
         print(f"\n✓ Best hyperparameters saved to: tuning/best_hyperparameters.txt")
-        
+       
+        if use_ddp:
+            broadcast_object({"cmd": "stop"})
+
         return {
             "phase1_best_energy": best_energy,
             "phase1_best_ppl": best_energy_ppl,
@@ -397,9 +535,27 @@ def run_tuning_pipeline():
             "phase2_parameters": final_params,
             "improvement_pct": ((best_energy_ppl - best_ppl) / best_energy_ppl * 100) if isinstance(best_energy_ppl, float) and best_energy_ppl > 0 else 0
         }
+
+    if use_ddp:
+        broadcast_object({"cmd": "stop"})
     return None
 
 def main():
+    local_rank, device, use_ddp = setup_device()
+
+    if use_ddp and not dist.is_initialized():
+        dist.init_process_group(backend="nccl")
+
+    rank = get_rank()
+
+    if use_ddp and not is_rank0():
+        try:
+            ddp_worker_loop(device, use_ddp, local_rank)
+        finally:
+            if dist.is_initialized():
+                dist.destroy_process_group()
+        return
+
     print("PC TRANSFORMER - TWO-PHASE HYPERPARAMETER TUNING")
     print("="*60)
     print("PHASE 1: Find stable architecture (minimize Energy)")
@@ -407,7 +563,7 @@ def main():
     print("="*60)
 
     try:
-        results = run_tuning_pipeline()
+        results = run_tuning_pipeline(device, use_ddp, local_rank)
         if results:
             print(f"\n{'='*60}")
             print("TUNING COMPLETED SUCCESSFULLY")
@@ -428,6 +584,9 @@ def main():
         print(f"Error during tuning: {e}")
         import traceback
         traceback.print_exc()
+    finally:
+        if use_ddp and dist.is_initialized():
+            dist.destroy_process_group()
 
 if __name__ == "__main__":
     main()

--- a/tuning/tune_model.py
+++ b/tuning/tune_model.py
@@ -12,7 +12,6 @@ import torch
 import optuna
 from optuna.storages import JournalStorage, JournalFileStorage
 import torch.distributed as dist
-from torch.nn.parallel import DistributedDataParallel as DDP
 from utils.device_utils import setup_device
 
 from training import train
@@ -119,7 +118,7 @@ def define_search_space_phase2(trial, best_params):
         "dropout": trial.suggest_float("dropout", max(0.0, dropout - 0.02), min(0.15, dropout + 0.02)),
     }
 
-def create_model(params, device, use_ddp=False, local_rank=0):
+def create_model(params, device, use_distributed=False, local_rank=0):
     """
     Assembles the model, config, and data for a single trial.
 
@@ -166,23 +165,19 @@ def create_model(params, device, use_ddp=False, local_rank=0):
     model.register_all_lateral_weights() 
     model = model.to(device)
 
-    if use_ddp:
-        model = DDP(
-            model,
-            device_ids=[local_rank],
-            output_device=local_rank,
-            find_unused_parameters=True,
-        )
+    if use_distributed:
+        for param in model.parameters():
+            dist.broadcast(param.data, src=0)
 
     train_loader, valid_loader, _ = get_loaders(
         batch_size=params["batch_size"], 
         block_size=params["block_size"], 
-        distributed=use_ddp
+        distributed=use_distributed
     )
     
     return model, config, train_loader, valid_loader, device
 
-def run_trial_with_params(params, trial_number, device, use_ddp, local_rank):
+def run_trial_with_params(params, trial_number, device, use_distributed, local_rank):
     """Run one training/evaluation trial with given params; returns metrics or instability flag (DDP-aware)."""
     model = None
 
@@ -190,7 +185,7 @@ def run_trial_with_params(params, trial_number, device, use_ddp, local_rank):
         model, config, train_loader, valid_loader, device = create_model(
             params,
             device=device,
-            use_ddp=use_ddp,
+            use_distributed=use_distributed,
             local_rank=local_rank,
         )
 
@@ -216,7 +211,7 @@ def run_trial_with_params(params, trial_number, device, use_ddp, local_rank):
             or train_energy > ENERGY_STABILITY_THRESHOLD
         )
 
-        if use_ddp:
+        if use_distributed:
             unstable_tensor = torch.tensor(int(unstable), device=device)
             dist.all_reduce(unstable_tensor, op=dist.ReduceOp.MAX)
             unstable = bool(unstable_tensor.item())
@@ -235,7 +230,7 @@ def run_trial_with_params(params, trial_number, device, use_ddp, local_rank):
             device=device,
         )
 
-        if use_ddp:
+        if use_distributed:
             metrics = torch.tensor([val_energy, val_ppl], dtype=torch.float32, device=device)
             dist.all_reduce(metrics, op=dist.ReduceOp.SUM)
             metrics /= dist.get_world_size()
@@ -256,7 +251,7 @@ def run_trial_with_params(params, trial_number, device, use_ddp, local_rank):
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
 
-def run_phase1_trial(trial, device, use_ddp, local_rank):
+def run_phase1_trial(trial, device, use_distributed, local_rank):
     """
     Phase 1 Trial Execution
     
@@ -273,7 +268,7 @@ def run_phase1_trial(trial, device, use_ddp, local_rank):
     """
     params = define_search_space(trial)
 
-    if use_ddp:
+    if use_distributed:
         broadcast_object({
             "cmd": "trial",
             "trial_number": trial.number,
@@ -286,7 +281,7 @@ def run_phase1_trial(trial, device, use_ddp, local_rank):
         params=params,
         trial_number=trial.number,
         device=device,
-        use_ddp=use_ddp,
+        use_distributed=use_distributed,
         local_rank=local_rank,
     )
 
@@ -311,7 +306,7 @@ def run_phase1_trial(trial, device, use_ddp, local_rank):
 
     return float(result["val_energy"])
 
-def run_phase2_trial(trial, best_params, device, use_ddp, local_rank):
+def run_phase2_trial(trial, best_params, device, use_distributed, local_rank):
     """
     Phase 2 Trial Execution
     
@@ -330,7 +325,7 @@ def run_phase2_trial(trial, best_params, device, use_ddp, local_rank):
     continuous_params = define_search_space_phase2(trial, best_params)
     params = {**best_params, **continuous_params}
     
-    if use_ddp:
+    if use_distributed:
         broadcast_object({
             "cmd": "trial",
             "trial_number": trial.number,
@@ -346,7 +341,7 @@ def run_phase2_trial(trial, best_params, device, use_ddp, local_rank):
         params=params,
         trial_number=trial.number,
         device=device,
-        use_ddp=use_ddp,
+        use_distributed=use_distributed,
         local_rank=local_rank,
     )
 
@@ -370,7 +365,7 @@ def run_phase2_trial(trial, best_params, device, use_ddp, local_rank):
 
     return float(result["val_ppl"])
 
-def ddp_worker_loop(device, use_ddp, local_rank):
+def distributed_worker_loop(device, use_distributed, local_rank):
     """Listen for broadcasted commands and execute trials until a stop signal is received."""
     while True:
         command = broadcast_object(None)
@@ -382,11 +377,11 @@ def ddp_worker_loop(device, use_ddp, local_rank):
             params=command["params"],
             trial_number=command["trial_number"],
             device=device,
-            use_ddp=use_ddp,
+            use_distributed=use_distributed,
             local_rank=local_rank,
         )
 
-def run_tuning_pipeline(device, use_ddp, local_rank):
+def run_tuning_pipeline(device, use_distributed, local_rank):
     """
     Coordinates the two-phase tuning pipeline
 
@@ -421,7 +416,7 @@ def run_tuning_pipeline(device, use_ddp, local_rank):
         lambda trial: run_phase1_trial(
             trial,
             device=device,
-            use_ddp=use_ddp,
+            use_distributed=use_distributed,
             local_rank=local_rank,
         ),
         n_trials=50,
@@ -446,7 +441,7 @@ def run_tuning_pipeline(device, use_ddp, local_rank):
         for key in ['lr', 'inference_lr', 'dropout']:
             print(f"  {key}: {best_params.get(key)}")
     else:
-        if use_ddp:
+        if use_distributed:
             broadcast_object({"cmd": "stop"})
         return None
 
@@ -478,7 +473,7 @@ def run_tuning_pipeline(device, use_ddp, local_rank):
             trial,
             best_params,
             device=device,
-            use_ddp=use_ddp,
+            use_distributed=use_distributed,
             local_rank=local_rank,
         )
 
@@ -524,7 +519,7 @@ def run_tuning_pipeline(device, use_ddp, local_rank):
         
         print(f"\n✓ Best hyperparameters saved to: tuning/best_hyperparameters.txt")
        
-        if use_ddp:
+        if use_distributed:
             broadcast_object({"cmd": "stop"})
 
         return {
@@ -536,21 +531,21 @@ def run_tuning_pipeline(device, use_ddp, local_rank):
             "improvement_pct": ((best_energy_ppl - best_ppl) / best_energy_ppl * 100) if isinstance(best_energy_ppl, float) and best_energy_ppl > 0 else 0
         }
 
-    if use_ddp:
+    if use_distributed:
         broadcast_object({"cmd": "stop"})
     return None
 
 def main():
-    local_rank, device, use_ddp = setup_device()
+    local_rank, device, use_distributed = setup_device()
 
-    if use_ddp and not dist.is_initialized():
+    if use_distributed and not dist.is_initialized():
         dist.init_process_group(backend="nccl")
 
     rank = get_rank()
 
-    if use_ddp and not is_rank0():
+    if use_distributed and not is_rank0():
         try:
-            ddp_worker_loop(device, use_ddp, local_rank)
+            distributed_worker_loop(device, use_distributed, local_rank)
         finally:
             if dist.is_initialized():
                 dist.destroy_process_group()
@@ -563,7 +558,7 @@ def main():
     print("="*60)
 
     try:
-        results = run_tuning_pipeline(device, use_ddp, local_rank)
+        results = run_tuning_pipeline(device, use_distributed, local_rank)
         if results:
             print(f"\n{'='*60}")
             print("TUNING COMPLETED SUCCESSFULLY")
@@ -585,7 +580,7 @@ def main():
         import traceback
         traceback.print_exc()
     finally:
-        if use_ddp and dist.is_initialized():
+        if use_distributed and dist.is_initialized():
             dist.destroy_process_group()
 
 if __name__ == "__main__":

--- a/tuning/tune_model.py
+++ b/tuning/tune_model.py
@@ -144,8 +144,9 @@ def create_model(params):
         alpha=0.5,
     )
 
-    model = PCTransformer(config).to(device)
+    model = PCTransformer(config)
     model.register_all_lateral_weights() 
+    model = model.to(device)
     train_loader, valid_loader, _ = get_loaders(batch_size=params["batch_size"], block_size=params["block_size"], distributed=False)
     
     return model, config, train_loader, valid_loader, device

--- a/utils/device_utils.py
+++ b/utils/device_utils.py
@@ -1,4 +1,5 @@
 import torch
+import torch.nn.functional as F
 from typing import List, Callable, Any, Optional
 import os
 import gc
@@ -91,3 +92,30 @@ def setup_device():
         device = torch.device("cpu")
         ddp = False
     return local_rank, device, ddp
+
+def sync_pc_weights(model):
+    """
+    Manually average PC-updated weights across DDP ranks.
+
+    Needed because this model updates parameters directly during forward,
+    so DDP gradient hooks are bypassed.
+    """
+    if not dist.is_available() or not dist.is_initialized():
+        return
+
+    world_size = dist.get_world_size()
+    if world_size == 1:
+        return
+
+    base_model = model.module if hasattr(model, "module") else model
+
+    with torch.no_grad():
+        for name, param in base_model.named_parameters():
+            if not torch.is_floating_point(param):
+                continue
+
+            dist.all_reduce(param.data, op=dist.ReduceOp.SUM)
+            param.data.div_(world_size)
+
+            if name.endswith("W_lateral"):
+                param.data.copy_(F.normalize(param.data, p=2, dim=1))

--- a/utils/device_utils.py
+++ b/utils/device_utils.py
@@ -107,10 +107,8 @@ def sync_pc_weights(model):
     if world_size == 1:
         return
 
-    base_model = model.module if hasattr(model, "module") else model
-
     with torch.no_grad():
-        for name, param in base_model.named_parameters():
+        for name, param in model.named_parameters():
             if not torch.is_floating_point(param):
                 continue
 


### PR DESCRIPTION
### Summary

Fixes DDP behavior for training and tuning by keeping all ranks synchronized after local pc weight updates, while preserving the existing two-phase tuning flow.

### Changes
**1. Manual PC weight synchronization in DDP** https://github.com/iCog-Labs-Dev/PC-Transformers/commit/49e9743fb45d81f6185a2da37ed2f0438bbfcfd5
Added manual synchronization after the local PC forward update so weights updated directly inside the pc path are averaged across ranks. This is needed because these updates bypass standard DDP gradient synchronization.

**2. DDP-safe lateral weight registration** https://github.com/iCog-Labs-Dev/PC-Transformers/commit/35660d487c56a4528855487b876578225dc619a2
Updated model initialization so lateral weights are registered before moving the model to device and before DDP wrapping. Also fixed the registered `layer_type` names to match the actual forward-pass names: `linear_attn`, `fc2`, and `linear_output`.

**3. DDP support for tuning** https://github.com/iCog-Labs-Dev/PC-Transformers/commit/c0544524e8ed53fefab31665ece6e07dfc03cf85
Added DDP support to `tuning/tune_model.py` while keeping Optuna controlled by rank 0. Rank 0 samples each trial, broadcasts the trial parameters to worker ranks, uses distributed loaders, and averages validation metrics across ranks. The two-phase tuning logic remains unchanged: Phase 1 minimizes energy, Phase 2 minimizes perplexity.

### Results

Training DDP sync check confirmed the expected behavior:
- Initial model state is synchronized across ranks: `max_param_diff_from_rank0=0.00000000e+00`
- Local PC update causes rank divergence: `max_param_diff_from_rank0=4.00000215e-02`
- Manual sync restores identical weights: `max_param_diff_from_rank0=0.00000000e+00`

The largest temporary divergence during training was in `embedding.word_embeddings.weight`, followed by output layer parameters, which is expected because each rank sees a different local batch.

Tuning DDP sync check also confirmed the expected behavior:
- Rank 0 started on `cuda:0`, rank 1 started on `cuda:1`
- Both ranks ran the same tuning trial with matching train/validation loader sizes
- Initial model state was synchronized: `max_param_diff_from_rank0=0.00000000e+00`
- Local PC update caused temporary divergence: `max_param_diff_from_rank0=1.03277713e-03`
- Manual sync restored identical weights: `max_param_diff_from_rank0=0.00000000e+00`

This confirms that both training and tuning now keep DDP ranks synchronized after local PC updates.