### PR TITLE
This PR enhances the development branch of the PC-Transformer with the following updates:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ __pycache__/
 *.pkl
 *.json
 *.pt
+*.log
+*.png
 !tuning/bayesian_tuning_results.txt 
 *.db
 *.whl

--- a/data_preparation/config.py
+++ b/data_preparation/config.py
@@ -11,7 +11,8 @@ valid_path = data_dir / "validation.csv"
 test_path = data_dir / "test.csv"
 
 # Tokenizer parameters
-vocab_size = 11707
+
+vocab_size = 11707 # Optimized subword-centric vocabulary size after GPT2
 
 # [MASK] exists only for BERT masked language modeling.
 # special_tokens = ["[UNK]", "[CLS]", "[SEP]", "[PAD]", "[MASK]"]

--- a/data_preparation/config.py
+++ b/data_preparation/config.py
@@ -13,11 +13,4 @@ test_path = data_dir / "test.csv"
 # Tokenizer parameters
 
 vocab_size = 11707 # Optimized subword-centric vocabulary size after GPT2
-
-# [MASK] exists only for BERT masked language modeling.
-# special_tokens = ["[UNK]", "[CLS]", "[SEP]", "[PAD]", "[MASK]"]
 special_tokens = ["[UNK]", "[BOS]", "[EOS]", "[PAD]"]
-
-# Training parameters
-batch_size = 8
-max_len = 208   # sequence length 

--- a/data_preparation/config.py
+++ b/data_preparation/config.py
@@ -11,5 +11,12 @@ valid_path = data_dir / "validation.csv"
 test_path = data_dir / "test.csv"
 
 # Tokenizer parameters
-vocab_size = 1024
-special_tokens = ["[UNK]", "[CLS]", "[SEP]", "[PAD]", "[MASK]"]
+vocab_size = 11707
+
+# [MASK] exists only for BERT masked language modeling.
+# special_tokens = ["[UNK]", "[CLS]", "[SEP]", "[PAD]", "[MASK]"]
+special_tokens = ["[UNK]", "[BOS]", "[EOS]", "[PAD]"]
+
+# Training parameters
+batch_size = 8
+max_len = 208   # sequence length 

--- a/data_preparation/config.py
+++ b/data_preparation/config.py
@@ -12,5 +12,5 @@ test_path = data_dir / "test.csv"
 
 # Tokenizer parameters
 
-vocab_size = 11707 # Optimized subword-centric vocabulary size after GPT2
+vocab_size = 11711 # Optimized subword-centric vocabulary size after GPT2
 special_tokens = ["[UNK]", "[BOS]", "[EOS]", "[PAD]"]

--- a/data_preparation/dataloader.py
+++ b/data_preparation/dataloader.py
@@ -33,7 +33,7 @@ def get_loaders(batch_size: int, block_size: int, distributed: bool = False, str
         batch_size= batch_size, 
         sampler=train_sampler,
         shuffle=(train_sampler is None), 
-        drop_last=True
+        drop_last=False
     )
     valid_loader = DataLoader(
         valid_dataset, 

--- a/data_preparation/dataset.py
+++ b/data_preparation/dataset.py
@@ -3,11 +3,16 @@ from pathlib import Path
 from torch.utils.data import Dataset
 
 class EncodedDataset(Dataset):
+<<<<<<< HEAD
     """ Dataset that splits token ID tensors into input-target sequences for next-token prediction using sliding window."""
     def __init__(self, file_path, block_size, stride=None):
         if block_size < 1:
             raise ValueError("block_size must be at least 1.")
 
+=======
+    """ Dataset that splits token ID tensors into input-target sequences for next-token prediction, with padding."""
+    def __init__(self, file_path, block_size, pad_token_id=3):
+>>>>>>> a53d33d (Optimize data loading: Implement sequence padding and disable drop_last to prevent data loss on small datasets.)
         self.block_size = block_size
         self.stride = 1 if stride is None else stride
         if self.stride < 1:
@@ -19,15 +24,17 @@ class EncodedDataset(Dataset):
         tokens = torch.load(file_path, weights_only=False)
         window_size = block_size + 1
 
-        if len(tokens) < window_size:
-            self.sequences = torch.empty(
-                (0, window_size),
-                dtype=tokens.dtype,
-                device=tokens.device,
-            )
-        else:
-            # `unfold` keeps overlapping windows as a view instead of copying the corpus.
-            self.sequences = tokens.unfold(0, window_size, self.stride)
+
+        # Calculate how much padding we need to avoid throwing away data
+        chunk_size = block_size + 1
+        remainder = len(tokens) % chunk_size
+        
+        if remainder > 0:
+            padding_len = chunk_size - remainder
+            padding = torch.full((padding_len,), pad_token_id, dtype=tokens.dtype)
+            tokens = torch.cat([tokens, padding])
+            
+        self.sequences = tokens.view(-1, chunk_size)
 
     def __len__(self):
         return len(self.sequences)

--- a/data_preparation/dataset.py
+++ b/data_preparation/dataset.py
@@ -3,16 +3,13 @@ from pathlib import Path
 from torch.utils.data import Dataset
 
 class EncodedDataset(Dataset):
-<<<<<<< HEAD
-    """ Dataset that splits token ID tensors into input-target sequences for next-token prediction using sliding window."""
-    def __init__(self, file_path, block_size, stride=None):
+
+    """ Dataset that splits token ID tensors into input-target sequences for next-token prediction, with padding."""
+    def __init__(self, file_path, block_size, stride=None, pad_token_id=3):
+
         if block_size < 1:
             raise ValueError("block_size must be at least 1.")
 
-=======
-    """ Dataset that splits token ID tensors into input-target sequences for next-token prediction, with padding."""
-    def __init__(self, file_path, block_size, pad_token_id=3):
->>>>>>> a53d33d (Optimize data loading: Implement sequence padding and disable drop_last to prevent data loss on small datasets.)
         self.block_size = block_size
         self.stride = 1 if stride is None else stride
         if self.stride < 1:

--- a/data_preparation/dataset.py
+++ b/data_preparation/dataset.py
@@ -4,7 +4,9 @@ from torch.utils.data import Dataset
 
 class EncodedDataset(Dataset):
 
-    """ Dataset that splits token ID tensors into input-target sequences for next-token prediction, with padding."""
+    """Dataset that loads a tokenized file and builds overlapping sliding-window sequences
+    for next-token prediction.  The tail of the token stream is padded just enough to
+    form one final complete window so no tokens are discarded."""
     def __init__(self, file_path, block_size, stride=None, pad_token_id=3):
 
         if block_size < 1:
@@ -21,17 +23,33 @@ class EncodedDataset(Dataset):
         tokens = torch.load(file_path, weights_only=False)
         window_size = block_size + 1
 
+        # Guard: if the file has fewer tokens than one window, return an empty dataset
+        # (matches the original behaviour for very small or empty token files).
+        if len(tokens) < window_size:
+            self.sequences = torch.empty(
+                (0, window_size),
+                dtype=tokens.dtype,
+                device=tokens.device,
+            )
+        else:
+            # Pad the tail so no tokens are thrown away.
+            # unfold() stops when there are not enough tokens left for a full window.
+            # We calculate how many tokens remain after the last complete window and
+            # pad just enough to turn them into one more complete window.
+            N = len(tokens)
+            last_start = ((N - window_size) // self.stride) * self.stride
+            last_end   = last_start + window_size
+            leftover   = N - last_end          # tokens not covered by any complete window
 
-        # Calculate how much padding we need to avoid throwing away data
-        chunk_size = block_size + 1
-        remainder = len(tokens) % chunk_size
-        
-        if remainder > 0:
-            padding_len = chunk_size - remainder
-            padding = torch.full((padding_len,), pad_token_id, dtype=tokens.dtype)
-            tokens = torch.cat([tokens, padding])
-            
-        self.sequences = tokens.view(-1, chunk_size)
+            if leftover > 0:
+                next_start = last_start + self.stride
+                pad_len    = next_start + window_size - N
+                padding    = torch.full((pad_len,), pad_token_id, dtype=tokens.dtype)
+                tokens     = torch.cat([tokens, padding])
+
+            # Overlapping sliding windows — each token appears in multiple sequences,
+            # giving the model richer contextual coverage of the corpus.
+            self.sequences = tokens.unfold(0, window_size, self.stride)
 
     def __len__(self):
         return len(self.sequences)

--- a/data_preparation/prepare_tokens.py
+++ b/data_preparation/prepare_tokens.py
@@ -25,7 +25,7 @@ def build_tokenizer():
 
     trainer = BpeTrainer(
         special_tokens = special_tokens,
-        vocab_size = vocab_size + len(special_tokens)
+        vocab_size = vocab_size 
         )
 
     paths = [train_path, valid_path, test_path]

--- a/data_preparation/prepare_tokens.py
+++ b/data_preparation/prepare_tokens.py
@@ -25,7 +25,7 @@ def build_tokenizer():
 
     trainer = BpeTrainer(
         special_tokens = special_tokens,
-        vocab_size = vocab_size
+        vocab_size = vocab_size + len(special_tokens)
         )
 
     paths = [train_path, valid_path, test_path]

--- a/data_preparation/prepare_tokens.py
+++ b/data_preparation/prepare_tokens.py
@@ -25,7 +25,7 @@ def build_tokenizer():
 
     trainer = BpeTrainer(
         special_tokens = special_tokens,
-        vocab_size = vocab_size + len(special_tokens)
+        vocab_size = vocab_size
         )
 
     paths = [train_path, valid_path, test_path]
@@ -34,7 +34,8 @@ def build_tokenizer():
             raise FileNotFoundError(f"Dataset file not found at: {path}")
 
     start_time = time.perf_counter()
-    tokenizer.train(files=[str(train_path)], trainer=trainer)
+    paths = [train_path, valid_path, test_path]
+    tokenizer.train(files=[str(p) for p in paths], trainer=trainer)
     elapsed = time.perf_counter() - start_time
 
     tokenizer.save(str(tokenizer_path))

--- a/predictive_coding/pc_layer.py
+++ b/predictive_coding/pc_layer.py
@@ -55,7 +55,7 @@ class PCLayer(nn.Module):
         self._x_cache: Dict[str, torch.Tensor] = {}
         self._mu_cache: Dict[str, torch.Tensor] = {}
         self._error_cache: Dict[str, torch.Tensor] = {}
-        self._energy = 0.0
+        self._energy_list = []
         self._errors = []
     
     def register_lateral(self, layer_type: str, size: int):
@@ -121,7 +121,7 @@ class PCLayer(nn.Module):
             # compute energy
             error = target_activity - mu
             energy, step_errors = finalize_step(mu, target_activity, error, t, layer_type, self.energy_fn_name)
-            self._energy += energy
+            self._energy_list.append(energy)
             self._errors.extend(step_errors)
             return mu_word
         
@@ -181,7 +181,7 @@ class PCLayer(nn.Module):
         
         error = target_activity - mu
         energy, step_errors = finalize_step(mu, target_activity, error, t, layer_type, self.energy_fn_name)
-        self._energy += energy
+        self._energy_list.append(energy)
         self._errors.extend(step_errors)
 
         # update x cache
@@ -245,11 +245,11 @@ class PCLayer(nn.Module):
 
     def get_energy(self) -> Optional[float]:
         """Get the accumulated energy for the layer."""
-        return float(self._energy)
+        return float(sum(self._energy_list)) if self._energy_list else 0.0
 
     def clear_energy(self):
         """Clear the stored energy and cached states for the layer."""
-        self._energy = 0.0
+        self._energy_list = []
         self._x_cache.clear()
         self._mu_cache.clear()
         

--- a/predictive_coding/pc_layer.py
+++ b/predictive_coding/pc_layer.py
@@ -244,8 +244,8 @@ class PCLayer(nn.Module):
         return self._error_cache.get(layer_type, None)
 
     def get_energy(self) -> Optional[float]:
-        """Get the accumulated energy for the layer."""
-        return float(sum(self._energy_list)) if self._energy_list else 0.0
+        """Get the last converged energy for the layer."""
+        return float(self._energy_list[-1]) if self._energy_list else 0.0
 
     def clear_energy(self):
         """Clear the stored energy and cached states for the layer."""
@@ -254,8 +254,12 @@ class PCLayer(nn.Module):
         self._mu_cache.clear()
         
     def get_errors(self) -> list:
-        """Get the list of error values accumulated during inference."""
-        return self._errors
+        """Get the errors from the most recent converged iteration."""
+        # Each step can contribute multiple error entries, so we find the last unique 'step'
+        if not self._errors:
+            return []
+        last_step_val = self._errors[-1]["step"]
+        return [err for err in self._errors if err["step"] == last_step_val]
 
     def clear_errors(self):
         """Clear the stored errors for the layer."""

--- a/predictive_coding/pc_layer.py
+++ b/predictive_coding/pc_layer.py
@@ -55,7 +55,7 @@ class PCLayer(nn.Module):
         self._x_cache: Dict[str, torch.Tensor] = {}
         self._mu_cache: Dict[str, torch.Tensor] = {}
         self._error_cache: Dict[str, torch.Tensor] = {}
-        self._energy_list = []
+        self._energy_scalar = 0.0
         self._errors = []
     
     def register_lateral(self, layer_type: str, size: int):
@@ -121,7 +121,7 @@ class PCLayer(nn.Module):
             # compute energy
             error = target_activity - mu
             energy, step_errors = finalize_step(mu, target_activity, error, t, layer_type, self.energy_fn_name)
-            self._energy_list.append(energy)
+            self._energy_scalar = energy  # overwrite each step; only the last T-step survives
             self._errors.extend(step_errors)
             return mu_word
         
@@ -181,7 +181,7 @@ class PCLayer(nn.Module):
         
         error = target_activity - mu
         energy, step_errors = finalize_step(mu, target_activity, error, t, layer_type, self.energy_fn_name)
-        self._energy_list.append(energy)
+        self._energy_scalar = energy  # overwrite each step; only the last T-step survives
         self._errors.extend(step_errors)
 
         # update x cache
@@ -244,12 +244,12 @@ class PCLayer(nn.Module):
         return self._error_cache.get(layer_type, None)
 
     def get_energy(self) -> Optional[float]:
-        """Get the last converged energy for the layer."""
-        return float(self._energy_list[-1]) if self._energy_list else 0.0
+        """Get the energy from the final inference step (T) for the layer."""
+        return float(self._energy_scalar)
 
     def clear_energy(self):
         """Clear the stored energy and cached states for the layer."""
-        self._energy_list = []
+        self._energy_scalar = 0.0
         self._x_cache.clear()
         self._mu_cache.clear()
         

--- a/training.py
+++ b/training.py
@@ -37,7 +37,7 @@ def train(model, dataloader, config, global_step, device, logger):
 
     base_model = model.module if hasattr(model, 'module') else model
     output_pc_layer = base_model.output.pc_layer
-    
+        
     for batch_idx, batch in enumerate(dataloader):
         input_ids = batch["input_ids"].to(device)
         target_ids = batch["target_ids"].to(device)
@@ -67,7 +67,7 @@ def train(model, dataloader, config, global_step, device, logger):
         ce_loss = F.cross_entropy(
             logits.view(-1, logits.size(-1)),
             target_ids.view(-1),
-            ignore_index=0
+            ignore_index=3  # 3 == [PAD] token ID, matches pad_token_id in dataset.py
         )
         total_ce_loss += ce_loss.item()
 

--- a/utils/pc_utils.py
+++ b/utils/pc_utils.py
@@ -254,7 +254,8 @@ def step_attn(
     mu = mu_heads.transpose(1, 2).contiguous().view(B, S, E)
     bu_err = target - mu
     
-    error = bu_err - td_err if td_err is not None else bu_err  
+    # deleted to insert the delta_x after the for loop below
+    # error = bu_err - td_err if td_err is not None else bu_err  
      
     scale = 1.0 / (head_dim ** 0.5)
 
@@ -312,7 +313,10 @@ def step_attn(
         delta_v = torch.einsum('bsh,eh->bse', dv, wv)
         
         delta_x += delta_q + delta_k + delta_v
-            
+
+    # Update delta_x with TD error if provided
+    delta_x = delta_x - td_err if td_err is not None else delta_x
+
     if lateral_conn is not None:
         delta_x = lateral_conn.forward(x, delta_x)
         x = x + inference_lr * delta_x

--- a/utils/pc_utils.py
+++ b/utils/pc_utils.py
@@ -385,7 +385,7 @@ def finalize_step(mu: torch.Tensor, target: torch.Tensor, error: torch.Tensor, t
     device = mu.device
     target = target.to(device)
     error = error.to(device)
-    energy = float(energy_fn(mu, target, energy_fn_name).mean().item())
+    energy = float(energy_fn(mu, target, energy_fn_name).sum().item())
     errors = [{"step": t, "type": layer_type, "error": error.mean().item()}]
     return energy, errors
     


### PR DESCRIPTION
/request-review @Nardos24 @quinbez

## Summary
This PR integrates enhanced predictive coding dynamics, updated tokenization, and optimized data loading.

## Commit Descriptions

### 20bdfe7 - Enhance new_attn branch with Sum-based energy and Temporal Energy Integration

 - **Summary:**
             --> Transitioned from mean-based to sum-based error aggregation globally across all PC layers to align with the Total Energy Minimization framework.
             --> Implemented stateful temporal tracking by capturing discrete energy values for each inference time-step.
- **Detail:**
             --> Modified finalize_step to calculate the total error across the entire tensor volume, providing a more comprehensive energy landscape than element-wise averaging.
             --> Enabled high-resolution debugging by replacing scalar energy summation with a sequential history of errors across all $T$ iterations. This enables detailed analysis of the model's convergence behavior during the iterative inference process.

### 16c978b - BERT style tokens replaced and Vocab_size enhanced
- **Summary:** 
                      -->  BERT-style tokens replaced by GPT-style token standardization
                      --> and vocab size is enhanced to 11707  
- **Detail:** Manually resolved conflicts in `config.py` and `prepare_tokens.py` to preserve vocab_size=11707 while adopting team's tokenizer improvements.

### 2f6694e - Updated BPE training to study all three dataset splits (Train, Valid, Test)
- **Summary:** Modified BPE tokenizer training to use train/validation/test splits
- **Detail:** Updated `prepare_tokens.py` to train tokenizer on combined dataset splits, improving vocabulary coverage.

### 0a400f8 - Implemented Steady-State energy reporting in pc_layer.py
- **Summary:** enhance the energy reporting to report from final inference step only.
- **Detail:** Modified `pc_layer.py` to report energy only after all T iterations, excluding transient intermediate states.

### af37ccc - feat: vocab_size excludes special token count and Applied td_err delta_x to include the missing top down error in for the latent state update.
- **Summary:**
       --> Integrated new_attn branch with updated vocab size 
       -->and TD error handling implemented
- **Detail:** 
        ---> vocab_size update to 11707,  
        --> And added delta_x = delta_x - td error if td error doesn't exist at the step attn function of  pc_utils.py

### 000f80a - Optimize data loading with sequence padding
- **Summary:** Added sequence padding for last batch to reserve the last batch from being dropped and disabled drop_last to prevent data loss
- **Detail:** Modified `dataloader.py` to pad sequences to block_size and disabled `drop_last` to ensure all data samples are used.




## Why do the run result of this new enhancement give large energy results?

### Technical Note: Energy Scale Discrepancy (Sum vs. Mean)

I wanted to provide a technical clarification on the significant difference in reported Energy values between our previous implementation and the current dev_enhanced branch.

The Discrepancy:

  - Original Approach: Used Mean-based aggregation at the tensor level and Sum-based aggregation across time-steps. (Resulted in Energy approximately 1.0)
 - Current Approach: Uses Sum-based aggregation at the tensor level and reports only the Last Time-Step. (Resulted in Energy approximately 50k).
 
Mathematical Rationale: 

The large jump in value is a direct result of the Tensor Volume. In our current architecture, a layer's activity matrix contains hundreds of thousands of individual elements.

 - Summing (Current): When we switch from mean() to sum() at the finalize_step, we are accumulating every single one of those hundreds of thousands of errors into a single scalar. This naturally results in a very large number (50k+).
 - Averaging (Previous): Averaging essentially compresses that entire matrix of errors back down to the scale of a single element, which is why the previous numbers stayed near 1.0.
 
Conclusion: 

Reporting only the final time-step in the current branch does not 'fix' the large numbers, because that single time-step is still a Sum of the entire tensor. We should not expect the current Energy to ever reduce down to the levels of the previous Approach, as they are measured on completely different mathematical scales. Our focus should be on the downward trend of the 50k value, rather than the absolute number itself.