### PR TITLE
feat(pc-energy): use CE for output-layer energy and keep hidden layers on pc_e

### DIFF
--- a/predictive_coding/pc_layer.py
+++ b/predictive_coding/pc_layer.py
@@ -23,6 +23,8 @@ class PCLayer(nn.Module):
         lr: float,
         inference_lr: float,
         energy_fn_name: str,
+        # Added output_energy_fn_name
+        output_energy_fn_name: str = "ce",
         num_heads: Optional[int] = None,
         n_embed: Optional[int] = None,
         optimizer_name: str = "adam",
@@ -39,6 +41,8 @@ class PCLayer(nn.Module):
         self.inference_lr = inference_lr
         self.clamp_value = 3.0
         self.energy_fn_name = energy_fn_name
+        # Store output energy fn name separately
+        self.output_energy_fn_name = output_energy_fn_name    # "ce"   — output layer
         self.num_heads = num_heads
         self.n_embed = n_embed
         self.optimizer = PCOptimizer(
@@ -120,7 +124,7 @@ class PCLayer(nn.Module):
 
             # compute energy
             error = target_activity - mu
-            energy, step_errors = finalize_step(mu, target_activity, error, t, layer_type, self.energy_fn_name)
+            energy, step_errors = finalize_step(mu, target_activity, error, t, layer_type, self.energy_fn_name, self.output_energy_fn_name)# output_energy_fn_name passed for consistent signature
             self._energy_scalar = energy  # overwrite each step; only the last T-step survives
             self._errors.extend(step_errors)
             return mu_word
@@ -180,7 +184,7 @@ class PCLayer(nn.Module):
          self._error_cache[layer_type] = bu_err.detach().clone()   
         
         error = target_activity - mu
-        energy, step_errors = finalize_step(mu, target_activity, error, t, layer_type, self.energy_fn_name)
+        energy, step_errors = finalize_step(mu, target_activity, error, t, layer_type, self.energy_fn_name, self.output_energy_fn_name) # Pass output_energy_fn_name to finalize_step
         self._energy_scalar = energy  # overwrite each step; only the last T-step survives
         self._errors.extend(step_errors)
 

--- a/utils/config_utils.py
+++ b/utils/config_utils.py
@@ -32,7 +32,7 @@ def load_best_config():
         "batch_size": 8,
         "num_epochs": 5,
         "internal_energy_fn_name": "pc_e",
-        "output_energy_fn_name": "pc_e",
+        "output_energy_fn_name": "ce",
         "combined_internal_weight": 0.8779955579743048,
         "combined_output_weight": 0.12200444202569516,
         "use_flash_attention": False,

--- a/utils/pc_utils.py
+++ b/utils/pc_utils.py
@@ -136,18 +136,15 @@ def step_linear(
         mu = layer_norm(mu)
             
     if layer_type=="linear_output":
-        probs = F.softmax(mu, dim=-1) 
-        bu_err= target - probs
-        dE_dp= bu_err
-        norm_term = (dE_dp * probs).sum(dim=-1, keepdim=True)
-        dE_dmu = probs * (dE_dp - norm_term)
-        error_proj= dE_dmu @ layer.weight     # project bottom-up error through weights
+        probs  = F.softmax(mu, dim=-1)
+        bu_err = target - probs   # reconstruction error (probability space)
+        dE_dmu = bu_err   # CE gradient w.r.t. logits
 
     else:    
         bu_err = target - mu 
         dE_dmu = bu_err
-        error_proj= dE_dmu @ layer.weight
-            
+        
+    error_proj= dE_dmu @ layer.weight       
     error = error_proj- td_err if td_err is not None else error_proj  
    
     if lateral_conn is not None:
@@ -374,7 +371,13 @@ def step_attn(
     return x, mu, bu_err, new_kv_cache
 
 ENERGY_FUNCTIONS = {
-    "pc_e": lambda mu, x: ((mu - x) ** 2) * 0.5,    
+    "pc_e": lambda mu, x: ((mu - x) ** 2) * 0.5,
+    # Added: CE energy for output layer
+    "ce": lambda mu, x: F.cross_entropy(
+        mu.reshape(-1, mu.size(-1)),
+        x.argmax(dim=-1).reshape(-1),
+        reduction="mean",
+    ),   
     "kld": lambda mu, x: torch.clamp(
         F.kl_div(mu.log_softmax(dim=-1), x, reduction="batchmean"), min=0.0, max=100.0
     ),
@@ -385,11 +388,17 @@ def energy_fn(mu: torch.Tensor, x: torch.Tensor,energy_fn_name: str) -> torch.Te
         raise ValueError(f"Unknown energy function: {energy_fn_name}. Choose from {list(ENERGY_FUNCTIONS.keys())}")
     return ENERGY_FUNCTIONS[energy_fn_name](mu, x)
 
-def finalize_step(mu: torch.Tensor, target: torch.Tensor, error: torch.Tensor, t: int, layer_type: str, energy_fn_name: str):
+def finalize_step(mu: torch.Tensor, target: torch.Tensor, error: torch.Tensor, t: int, layer_type: str, energy_fn_name: str, output_energy_fn_name: str = "ce"): # added: CE for output layer
     device = mu.device
     target = target.to(device)
     error = error.to(device)
-    energy = float(energy_fn(mu, target, energy_fn_name).sum().item())
+    # Route output layer to CE, hidden layers to pc_e
+    fn_name = (
+        output_energy_fn_name     # "ce"   — linear_output
+        if layer_type == "linear_output"
+        else energy_fn_name       # "pc_e" — all hidden layers
+    )
+    energy = float(energy_fn(mu, target, fn_name).sum().item())
     errors = [{"step": t, "type": layer_type, "error": error.mean().item()}]
     return energy, errors
     


### PR DESCRIPTION
This PR updates predictive-coding energy handling so the output layer can use cross-entropy (CE) while hidden layers continue using `pc_e`.

## Changes

### predictive_coding/pc_layer.py
- Added `output_energy_fn_name` to `PCLayer`
- Passed `output_energy_fn_name` into `finalize_step(...)` for output-layer energy routing
- Commit: 651977c

### utils/pc_utils.py
- Added "ce" to `ENERGY_FUNCTIONS`
- Updated `finalize_step(...)` to select:
  - `output_energy_fn_name` for `linear_output`
  - `energy_fn_name` for non-output layers
- Fixed energy computation to use the selected function name (`fn_name`)
- Updated `step_linear` output-layer error handling to use CE-style logits/probability behavior:
  - `bu_err = target - probs`
  - projected through output weights
- Commit: 21757c1

### utils/config_utils.py
- Changed default `output_energy_fn_name` from `pc_e` to `ce`
- Commit: 19adb3b

## Result
- Output-layer energy is now configurable and defaults to CE
- Hidden-layer energy behavior remains unchanged (`pc_e`)